### PR TITLE
Json path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ class ReadmeExample extends CornichonFeature {
           }
           """, ignoring = "Episodes", "Response")
    
-        And assert body_is(_ \ "Episodes",
+        And assert body_json_path_is("Episodes",
           """
             |                Title                    |   Released   | Episode | imdbRating |   imdbID    |
             | "Winter Is Coming"                      | "2011-04-17" |   "1"   |    "8.1"   | "tt1480055" |
@@ -58,9 +58,9 @@ class ReadmeExample extends CornichonFeature {
             | "Fire and Blood"                        | "2011-06-19" |  "10"   |    "8.4"   | "tt1851397" |
           """)
    
-        And assert body_array_size_is(_ \ "Episodes", 10)
+        And assert body_array_size_is("Episodes", 10)
    
-        And assert body_is(b => (b \ "Episodes")(0),
+        And assert body_json_path_is("Episodes[0]",
           """
           {
             "Title": "Winter Is Coming",
@@ -71,9 +71,9 @@ class ReadmeExample extends CornichonFeature {
           }
           """)
    
-        And assert body_is(b => (b \ "Episodes")(0) \ "Released", "2011-04-17")
+        And assert body_json_path_is("Episodes[0].Released", "2011-04-17")
    
-        And assert body_array_contains(_ \ "Episodes", 
+        And assert body_array_contains("Episodes", 
           """
           {
             "Title": "Winter Is Coming",
@@ -215,16 +215,16 @@ body_is(whiteList = true, expected = """
   """)
 ```
 
-It also possible to use [Json4s XPath](http://json4s.org/#xpath--hofs) extractors
+It also possible to use JsonPath like extractors
   
 ```scala
-body_is(_ \ "city", "Gotham city")
+body_json_path_is("city", "Gotham city")
 
-body_is(_ \ "hasSuperpowers", false)
+body_json_path_is("hasSuperpowers", false)
 
-body_is(_ \ "publisher" \ "name", "DC")
+body_json_path_is("publisher.name", "DC")
 
-body_is(_ \ "publisher" \ "foundationYear", 1934)
+body_json_path_is("publisher.foundationYear", 1934)
 
 ```
 
@@ -291,8 +291,6 @@ save("favorite-superhero" → "Batman")
 
 ```scala
 save_body_key("city", "batman-city")
-
-save_from_body(_ \ "city", "batman-city")
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -583,13 +583,13 @@ override lazy val requestTimeout = 100 millis
 
 In some cases it makes sense to declare ```extractors``` to avoid code duplication when dealing with ```session``` values.
 
-An extractor is responsible to describe how to build a value from an existing value in ```session```.
+An extractor is responsible to describe using a JsonPath how to build a value from an existing value in ```session```.
 
 For instance if most of your JSON responses contain a field ```id``` and you want to use it as a placeholder without always having to manually extract and save the value into the ```session``` you can write :
  
 ```scala
    override def registerExtractors = Map(
-     "response-id" → JsonMapper(HttpService.LastResponseBodyKey, v ⇒ (v \ "id").values.toString)
+     "response-id" → JsonMapper(HttpService.LastResponseBodyKey, "id")
    )
 ```
 
@@ -600,9 +600,9 @@ It works for all keys in ```Session```, let's say we also have objects registere
  
 ```scala
    override def registerExtractors = Map(
-     "response-id" → JsonMapper(HttpService.LastResponseBodyKey, v ⇒ (v \ "id").values.toString),
-     "customer-id" → JsonMapper("customer", v ⇒ (v \ "id").values.toString),
-     "product-id" → JsonMapper("product", v ⇒ (v \ "id").values.toString)
+     "response-version" → JsonMapper(HttpService.LastResponseBodyKey, "version"),
+     "customer-street" → JsonMapper("customer", "address.street"),
+     "product-first-rating" → JsonMapper("product", "rating[0].score")
    )
 ```
 

--- a/src/it/scala/com.github.agourlay.cornichon.examples/OpenMovieDatabase.scala
+++ b/src/it/scala/com.github.agourlay.cornichon.examples/OpenMovieDatabase.scala
@@ -42,7 +42,7 @@ class OpenMovieDatabase extends CornichonFeature {
           """
         )
 
-        And assert body_is(_ \ "imdbRating", "9.5")
+        And assert body_field_is("imdbRating", "9.5")
 
         And assert body_is(
           """
@@ -170,7 +170,7 @@ class OpenMovieDatabase extends CornichonFeature {
           """
         )
 
-        And assert body_is(_ \ "Episodes",
+        And assert body_field_is("Episodes",
           """
             |                Title                    |   Released   | Episode | imdbRating |   imdbID    |
             | "Winter Is Coming"                      | "2011-04-17" |   "1"   |    "8.1"   | "tt1480055" |
@@ -185,9 +185,9 @@ class OpenMovieDatabase extends CornichonFeature {
             | "Fire and Blood"                        | "2011-06-19" |  "10"   |    "8.4"   | "tt1851397" |
           """)
 
-        And assert body_array_size_is(_ \ "Episodes", 10)
+        And assert body_array_size_is("Episodes", 10)
 
-        And assert body_is(b => (b \ "Episodes")(0),
+        And assert body_field_is("Episodes[0]",
           """
           {
             "Title": "Winter Is Coming",
@@ -198,9 +198,9 @@ class OpenMovieDatabase extends CornichonFeature {
           }
           """)
 
-        And assert body_is(b => (b \ "Episodes")(0) \ "Released", "2011-04-17")
+        And assert body_field_is("Episodes[0].Released", "2011-04-17")
 
-        And assert body_array_contains(_ \ "Episodes", """
+        And assert body_array_contains("Episodes", """
           {
             "Title": "Winter Is Coming",
             "Released": "2011-04-17",

--- a/src/it/scala/com.github.agourlay.cornichon.examples/OpenMovieDatabase.scala
+++ b/src/it/scala/com.github.agourlay.cornichon.examples/OpenMovieDatabase.scala
@@ -30,35 +30,16 @@ class OpenMovieDatabase extends CornichonFeature {
             "Plot": "Several noble families fight for control of the mythical land of Westeros.",
             "Language": "English",
             "Country": "USA",
-            "Awards": "Won 1 Golden Globe. Another 133 wins & 250 nominations.",
             "Poster": "http://ia.media-imdb.com/images/M/MV5BMTYwOTEzMDMzMl5BMl5BanBnXkFtZTgwNzExODIzNzE@._V1_SX300.jpg",
             "Metascore": "N/A",
-            "imdbRating": "9.5",
-            "imdbVotes": "877,359",
             "imdbID": "tt0944947",
             "Type": "series",
             "Response": "True"
           }
-          """
+          """, ignoring = "imdbRating", "imdbVotes", "Awards"
         )
 
         And assert body_field_is("imdbRating", "9.5")
-
-        And assert body_is(
-          """
-          {
-            "Title": "Game of Thrones",
-            "Year": "2011–",
-            "Rated": "TV-MA",
-            "Released": "17 Apr 2011",
-            "Runtime": "56 min",
-            "Genre": "Adventure, Drama, Fantasy",
-            "Director": "N/A",
-            "Writer": "David Benioff, D.B. Weiss",
-            "Actors": "Peter Dinklage, Lena Headey, Emilia Clarke, Kit Harington"
-          }
-          """, ignoring = "Plot", "Language", "Country", "Awards", "Poster", "Metascore", "imdbRating", "imdbVotes", "imdbID", "Type", "Response"
-        )
 
         And assert body_is(whiteList = true,
           """

--- a/src/it/scala/com.github.agourlay.cornichon.examples/OpenMovieDatabase.scala
+++ b/src/it/scala/com.github.agourlay.cornichon.examples/OpenMovieDatabase.scala
@@ -39,7 +39,7 @@ class OpenMovieDatabase extends CornichonFeature {
           """, ignoring = "imdbRating", "imdbVotes", "Awards"
         )
 
-        And assert body_field_is("imdbRating", "9.5")
+        And assert body_json_path_is("imdbRating", "9.5")
 
         And assert body_is(whiteList = true,
           """
@@ -151,7 +151,7 @@ class OpenMovieDatabase extends CornichonFeature {
           """
         )
 
-        And assert body_field_is("Episodes",
+        And assert body_json_path_is("Episodes",
           """
             |                Title                    |   Released   | Episode | imdbRating |   imdbID    |
             | "Winter Is Coming"                      | "2011-04-17" |   "1"   |    "8.1"   | "tt1480055" |
@@ -168,7 +168,7 @@ class OpenMovieDatabase extends CornichonFeature {
 
         And assert body_array_size_is("Episodes", 10)
 
-        And assert body_field_is("Episodes[0]",
+        And assert body_json_path_is("Episodes[0]",
           """
           {
             "Title": "Winter Is Coming",
@@ -179,7 +179,7 @@ class OpenMovieDatabase extends CornichonFeature {
           }
           """)
 
-        And assert body_field_is("Episodes[0].Released", "2011-04-17")
+        And assert body_json_path_is("Episodes[0].Released", "2011-04-17")
 
         And assert body_array_contains("Episodes", """
           {

--- a/src/main/scala/com/github/agourlay/cornichon/CornichonFeature.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/CornichonFeature.scala
@@ -1,11 +1,7 @@
 package com.github.agourlay.cornichon
 
 import com.github.agourlay.cornichon.core._
-import com.github.agourlay.cornichon.dsl.DataTableParser
 import com.github.agourlay.cornichon.http.{ HttpDsl, HttpService }
-
-import org.json4s.JsonAST.JArray
-import org.json4s.jackson.JsonMethods._
 
 import scala.concurrent.duration._
 
@@ -34,11 +30,6 @@ trait CornichonFeature extends HttpDsl with ScalaTestIntegration {
     engine.runScenario(Session.newSession) {
       s.copy(steps = beforeEachScenario.toVector ++ s.steps ++ afterEachScenario)
     }
-
-  def parseDataTable(table: String): JArray = {
-    val sprayArray = DataTableParser.parseDataTable(table).asSprayJson
-    JArray(sprayArray.elements.map(v ⇒ parse(v.toString())).toList)
-  }
 
   def httpServiceByURL(baseUrl: String, timeout: FiniteDuration = requestTimeout) = new HttpService(baseUrl, timeout, globalClient, resolver, ec)
 

--- a/src/main/scala/com/github/agourlay/cornichon/core/Errors.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/core/Errors.scala
@@ -63,6 +63,14 @@ case class ResolverParsingError(error: Throwable) extends CornichonError {
   val msg = s"error thrown during resolver parsing ${error.getMessage}"
 }
 
+case class JsonPathParsingError(error: String) extends CornichonError {
+  val msg = s"error thrown during JsonPath parsing : $error"
+}
+
+case class JsonPathError(error: Throwable) extends CornichonError {
+  val msg = s"error thrown during JsonPath parsing ${error.getMessage}"
+}
+
 case class EmptyKeyException(s: Session) extends CornichonError {
   val msg = s"key value can not be empty - session is \n${s.prettyPrint}"
 }

--- a/src/main/scala/com/github/agourlay/cornichon/core/Resolver.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/core/Resolver.scala
@@ -4,13 +4,14 @@ import java.util.UUID
 
 import cats.data.Xor
 import cats.data.Xor.{ left, right }
+import com.github.agourlay.cornichon.json.CornichonJson
 import org.json4s.JsonAST.JValue
 import org.json4s.jackson.JsonMethods._
 import org.parboiled2._
 
 import scala.util._
 
-class Resolver(extractors: Map[String, Mapper]) {
+class Resolver(extractors: Map[String, Mapper]) extends CornichonJson {
 
   def findPlaceholders(input: String): List[Placeholder] =
     new PlaceholderParser(input).placeholdersRule.run() match {
@@ -71,8 +72,8 @@ class Resolver(extractors: Map[String, Mapper]) {
   }
 
   def runCustomMapper(input: String, mapper: Mapper) = mapper match {
-    case TextMapper(_, extract) ⇒ extract(input)
-    case JsonMapper(_, extract) ⇒ extract(parse(input))
+    case TextMapper(_, extract)  ⇒ extract(input)
+    case JsonMapper(_, jsonPath) ⇒ selectJsonPath(jsonPath, parse(input)).values.toString
   }
 }
 
@@ -111,4 +112,4 @@ sealed trait Mapper {
 
 case class TextMapper(key: String, extract: String ⇒ String) extends Mapper
 
-case class JsonMapper(key: String, extract: JValue ⇒ String) extends Mapper
+case class JsonMapper(key: String, jsonPath: String) extends Mapper

--- a/src/main/scala/com/github/agourlay/cornichon/dsl/Dsl.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/dsl/Dsl.scala
@@ -111,18 +111,12 @@ trait Dsl extends CornichonLogger {
   def session_contains(key: String, value: String, title: Option[String] = None) =
     RunnableStep(
       title = title.getOrElse(s"session '$key' equals '$value'"),
-      action = s ⇒ {
-        (s, SimpleStepAssertion(value, s.get(key)))
-      }
+      action = s ⇒ (s, SimpleStepAssertion(value, s.get(key)))
     )
 
   def show_session = DebugStep(s ⇒ s"Session content : \n${s.prettyPrint}")
 
-  def show_session(key: String) =
-    DebugStep { s ⇒
-      val value = s.get(key)
-      s"Session content for key '$key' is '$value'"
-    }
+  def show_session(key: String) = DebugStep(s ⇒ s"Session content for key '$key' is '${s.get(key)}'")
 
   def print_step(message: String) = DebugStep(s ⇒ message)
 

--- a/src/main/scala/com/github/agourlay/cornichon/http/HttpDsl.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/HttpDsl.scala
@@ -113,7 +113,7 @@ trait HttpDsl extends Dsl with CornichonJson {
       }, title = s"headers contain ${headers.mkString(", ")}"
     )
 
-  def body_field_is[A](jsonPath: String, expected: A, ignoring: String*) =
+  def body_json_path_is[A](jsonPath: String, expected: A, ignoring: String*) =
     transform_assert_session(
       key = LastResponseBodyKey,
       expected = s ⇒ resolveAndParse(expected, s),

--- a/src/main/scala/com/github/agourlay/cornichon/json/CornichonJson.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/json/CornichonJson.scala
@@ -4,6 +4,7 @@ import cats.data.Xor
 import cats.data.Xor.{ left, right }
 import com.github.agourlay.cornichon.core.{ CornichonError, MalformedJsonError }
 import com.github.agourlay.cornichon.dsl.DataTableParser
+
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 
@@ -12,7 +13,7 @@ import scala.util.{ Failure, Success, Try }
 trait CornichonJson {
 
   def parseJson[A](input: A): JValue = input match {
-    case s: String if s.trim.headOption.contains('|') ⇒ parse(DataTableParser.parseDataTable(s).asSprayJson.toString())
+    case s: String if s.trim.headOption.contains('|') ⇒ parseDataTable(s)
     case s: String if s.trim.headOption.contains('{') ⇒ parse(s)
     case s: String if s.trim.headOption.contains('[') ⇒ parse(s)
     case s: String                                    ⇒ JString(s)
@@ -21,6 +22,11 @@ trait CornichonJson {
     case i: Int                                       ⇒ JInt(i)
     case l: Long                                      ⇒ JLong(l)
     case b: Boolean                                   ⇒ JBool(b)
+  }
+
+  def parseDataTable(table: String): JArray = {
+    val sprayArray = DataTableParser.parseDataTable(table).asSprayJson
+    JArray(sprayArray.elements.map(v ⇒ parse(v.toString())).toList)
   }
 
   def parseJsonUnsafe[A](input: A): JValue =
@@ -39,4 +45,14 @@ trait CornichonJson {
     keys.foldLeft(input) { (j, k) ⇒
       j.removeField { r ⇒ r._1 == k && (input \ r._1) == r._2 }
     }
+
+  def selectJsonPath(path: String, json: JValue) = {
+    val parsedJsonPath = JsonPathParser.parseJsonPath(path)
+    val jsonPath = JsonPath.fromSegments(parsedJsonPath)
+    jsonPath.operations.foldLeft(json) { (j, op) ⇒ op.run(j) }
+  }
+
+  // traverse each node with operation and replace object by key using 'filterJsonRootKeys'
+  def removeJsonPath(path: String, json: JValue) = ???
+
 }

--- a/src/main/scala/com/github/agourlay/cornichon/json/JsonPath.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/json/JsonPath.scala
@@ -1,0 +1,28 @@
+package com.github.agourlay.cornichon.json
+
+import org.json4s.JsonAST.JValue
+
+case class JsonPath(path: String, operations: List[JsonPathOperation])
+
+object JsonPath {
+  def fromSegments(segments: List[JsonSegment]) = {
+    val path = segments.map(_.fullKey).mkString(".")
+    val operations = segments.map {
+      case JsonSegment(field, None)        ⇒ FieldSelection(field)
+      case JsonSegment(field, Some(index)) ⇒ ArrayFieldSelection(field, index)
+    }
+    JsonPath(path, operations)
+  }
+}
+
+sealed trait JsonPathOperation {
+  def run(json: JValue): JValue
+}
+
+case class FieldSelection(field: String) extends JsonPathOperation {
+  def run(json: JValue) = json \ field
+}
+
+case class ArrayFieldSelection(field: String, indice: Int) extends JsonPathOperation {
+  def run(json: JValue) = (json \ field)(indice)
+}

--- a/src/main/scala/com/github/agourlay/cornichon/json/JsonPathParser.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/json/JsonPathParser.scala
@@ -1,0 +1,43 @@
+package com.github.agourlay.cornichon.json
+
+import com.github.agourlay.cornichon.core.{ JsonPathError, JsonPathParsingError }
+import org.parboiled2._
+
+import scala.util.{ Success, Failure }
+
+class JsonPathParser(val input: ParserInput) extends Parser {
+
+  def placeholdersRule = rule {
+    oneOrMore(SegmentRule).separatedBy('.') ~ EOI
+  }
+
+  def SegmentRule = rule(Field ~ optIndex ~> JsonSegment)
+
+  val notAllowedInField = "\r\n[]. "
+
+  def optIndex = rule(optional('[' ~ Number ~ ']'))
+
+  def Field = rule(capture(oneOrMore(CharPredicate.Visible -- notAllowedInField)))
+
+  def Number = rule { capture(Digits) ~> (_.toInt) }
+
+  def Digits = rule { oneOrMore(CharPredicate.Digit) }
+}
+
+object JsonPathParser {
+  def parseJsonPath(input: String): List[JsonSegment] = {
+    val p = new JsonPathParser(input)
+    p.placeholdersRule.run() match {
+      case Failure(e: ParseError) ⇒
+        throw new JsonPathParsingError(p.formatError(e, new ErrorFormatter(showTraces = true)))
+      case Failure(e: Throwable) ⇒
+        throw new JsonPathError(e)
+      case Success(dt) ⇒
+        dt.toList
+    }
+  }
+}
+
+case class JsonSegment(field: String, index: Option[Int]) {
+  val fullKey = index.fold(s"$field") { index ⇒ s"$field[$index]" }
+}

--- a/src/test/scala/com/github/agourlay/cornichon/examples/CornichonExamplesSpec.scala
+++ b/src/test/scala/com/github/agourlay/cornichon/examples/CornichonExamplesSpec.scala
@@ -497,6 +497,6 @@ class CornichonExamplesSpec extends CornichonFeature {
   }
 
   override def registerExtractors = Map(
-    "name" → JsonMapper(HttpService.LastResponseBodyKey, v ⇒ (v \ "name").values.toString)
+    "name" → JsonMapper(HttpService.LastResponseBodyKey, "name")
   )
 }

--- a/src/test/scala/com/github/agourlay/cornichon/examples/CornichonExamplesSpec.scala
+++ b/src/test/scala/com/github/agourlay/cornichon/examples/CornichonExamplesSpec.scala
@@ -5,7 +5,7 @@ import java.util.Base64
 
 import akka.http.scaladsl.Http.ServerBinding
 import com.github.agourlay.cornichon.CornichonFeature
-import com.github.agourlay.cornichon.core.{ JsonMapper }
+import com.github.agourlay.cornichon.core.JsonMapper
 import com.github.agourlay.cornichon.examples.server.RestAPI
 import com.github.agourlay.cornichon.http.HttpService
 import scala.concurrent.Await
@@ -58,11 +58,11 @@ class CornichonExamplesSpec extends CornichonFeature {
           """)
 
         // Test part of response body by providing an extractor
-        Then assert body_is(_ \ "city", "Gotham city")
+        Then assert body_field_is("city", "Gotham city")
 
-        Then assert body_is(_ \ "hasSuperpowers", false)
+        Then assert body_field_is("hasSuperpowers", false)
 
-        Then assert body_is(_ \ "publisher", expected =
+        Then assert body_field_is("publisher", expected =
           """
           {
             "name":"DC",
@@ -70,17 +70,16 @@ class CornichonExamplesSpec extends CornichonFeature {
             "location":"Burbank, California"
           } """)
 
-        // No varargs
-        Then assert body_is(_ \ "publisher", expected =
+        Then assert body_field_is("publisher", expected =
           """
           {
             "name":"DC",
             "foundationYear":1934
-          } """, ignoring = Seq("location"))
+          } """, ignoring = "location")
 
-        Then assert body_is(_ \ "publisher" \ "name", "DC")
+        Then assert body_field_is("publisher.name", "DC")
 
-        Then assert body_is(_ \ "publisher" \ "foundationYear", 1934)
+        Then assert body_field_is("publisher.foundationYear", 1934)
 
         When I GET("/superheroes/Scalaman")
 
@@ -173,7 +172,7 @@ class CornichonExamplesSpec extends CornichonFeature {
 
           Then assert headers_contain("Content-Encoding" → "gzip")
 
-          Then assert body_is(_ \ "city", "Pankow")
+          Then assert body_field_is("city", "Pankow")
         }
 
         Then assert status_is(200)
@@ -386,7 +385,7 @@ class CornichonExamplesSpec extends CornichonFeature {
         When I GET("/superheroes/Batman")
 
         // Using registered extractor at the bottom
-        Then assert body_is(_ \ "name", "<name>")
+        Then assert body_field_is("name", "<name>")
 
         // Repeat series of Steps
         Repeat(3) {

--- a/src/test/scala/com/github/agourlay/cornichon/examples/CornichonExamplesSpec.scala
+++ b/src/test/scala/com/github/agourlay/cornichon/examples/CornichonExamplesSpec.scala
@@ -58,11 +58,11 @@ class CornichonExamplesSpec extends CornichonFeature {
           """)
 
         // Test part of response body by providing an extractor
-        Then assert body_field_is("city", "Gotham city")
+        Then assert body_json_path_is("city", "Gotham city")
 
-        Then assert body_field_is("hasSuperpowers", false)
+        Then assert body_json_path_is("hasSuperpowers", false)
 
-        Then assert body_field_is("publisher", expected =
+        Then assert body_json_path_is("publisher", expected =
           """
           {
             "name":"DC",
@@ -70,16 +70,16 @@ class CornichonExamplesSpec extends CornichonFeature {
             "location":"Burbank, California"
           } """)
 
-        Then assert body_field_is("publisher", expected =
+        Then assert body_json_path_is("publisher", expected =
           """
           {
             "name":"DC",
             "foundationYear":1934
           } """, ignoring = "location")
 
-        Then assert body_field_is("publisher.name", "DC")
+        Then assert body_json_path_is("publisher.name", "DC")
 
-        Then assert body_field_is("publisher.foundationYear", 1934)
+        Then assert body_json_path_is("publisher.foundationYear", 1934)
 
         When I GET("/superheroes/Scalaman")
 
@@ -172,7 +172,7 @@ class CornichonExamplesSpec extends CornichonFeature {
 
           Then assert headers_contain("Content-Encoding" → "gzip")
 
-          Then assert body_field_is("city", "Pankow")
+          Then assert body_json_path_is("city", "Pankow")
         }
 
         Then assert status_is(200)
@@ -385,7 +385,7 @@ class CornichonExamplesSpec extends CornichonFeature {
         When I GET("/superheroes/Batman")
 
         // Using registered extractor at the bottom
-        Then assert body_field_is("name", "<name>")
+        Then assert body_json_path_is("name", "<name>")
 
         // Repeat series of Steps
         Repeat(3) {

--- a/src/test/scala/com/github/agourlay/cornichon/examples/CornichonExamplesSpec.scala
+++ b/src/test/scala/com/github/agourlay/cornichon/examples/CornichonExamplesSpec.scala
@@ -357,7 +357,7 @@ class CornichonExamplesSpec extends CornichonFeature {
         )
 
         // Or with extractor
-        And I save_from_body(_ \ "city", "batman-city")
+        And I save_from_body("city", "batman-city")
 
         Then assert session_contains("batman-city" → "Gotham city")
 

--- a/src/test/scala/com/github/agourlay/cornichon/json/JsonPathParserSpec.scala
+++ b/src/test/scala/com/github/agourlay/cornichon/json/JsonPathParserSpec.scala
@@ -1,0 +1,64 @@
+package com.github.agourlay.cornichon.json
+
+import com.github.agourlay.cornichon.core.JsonPathParsingError
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{ Matchers, WordSpec }
+
+import JsonPathParserSpec._
+
+class JsonPathParserSpec extends WordSpec with Matchers with PropertyChecks {
+
+  "JsonPathParser" when {
+    "parseJsonPath" must {
+      "parse JsonPath containing a field without index" in {
+        forAll(fieldGen) { field ⇒
+          JsonPathParser.parseJsonPath(field) should be(List(JsonSegment(field, None)))
+        }
+      }
+
+      "parse JsonPath containing a field with index" in {
+        forAll(fieldGen, indiceGen) { (field, indice) ⇒
+          JsonPathParser.parseJsonPath(s"$field[$indice]") should be(List(JsonSegment(field, Some(indice))))
+        }
+      }
+
+      "parse JsonPath containing two fields without index" in {
+        forAll(fieldGen, fieldGen) { (field1, field2) ⇒
+          JsonPathParser.parseJsonPath(s"$field1.$field2") should be(List(JsonSegment(field1, None), JsonSegment(field2, None)))
+        }
+      }
+
+      "return error if it starts with '.'" in {
+        forAll(fieldGen, indiceGen) { (field, indice) ⇒
+          intercept[JsonPathParsingError] {
+            JsonPathParser.parseJsonPath(s".$field.")
+          }
+        }
+      }
+
+      "parse JsonPath containing a missing field" in {
+        forAll(fieldGen, indiceGen) { (field, indice) ⇒
+          intercept[JsonPathParsingError] {
+            JsonPathParser.parseJsonPath(s"$field.")
+          }
+        }
+      }
+
+      "parse JsonPath containing a broken index bracket" in {
+        forAll(fieldGen, indiceGen) { (field, indice) ⇒
+          intercept[JsonPathParsingError] {
+            JsonPathParser.parseJsonPath(s"$field[$indice[")
+          }
+        }
+      }
+    }
+  }
+}
+
+object JsonPathParserSpec {
+  val fieldGen = Gen.alphaStr.filter(_.nonEmpty)
+  def fieldsGen(n: Int) = Gen.listOfN(n, fieldGen)
+
+  val indiceGen = Gen.choose(0, Int.MaxValue)
+}


### PR DESCRIPTION
This is an experiment to introduce a ```JSON path like``` syntax for extractors to target https://github.com/agourlay/cornichon/issues/23

Here is a quick comparison:

```body_is(_ \ "publisher" \ "foundationYear", 1934)```
```body_field_is("publisher.foundationYear", 1934) ```

```body_is( b => (b \ "Episodes")(0), jsonString) ``` 
```body_field_is("Episodes[0]", jsonString) ```

```body_is( b => (b \ "Episodes")(0) \ "Released" , jsonString) ```
```body_field_is("Episodes[0].Released", jsonString) ```

Pros:
- extraction path can be displayed properly in the step description
- easier to use
- easier to read in the case of array extraction
- Json4s does not leak through the DSL

Cons:
- operation not type checked anymore
- forced to introduce another method ```body_field_is``` as overloading is not possible anymore because all args are Strings.

My opinion : 

I am quite satisfied by the solution as it would be possible to reuse the jsonPath infrastructure for ```ignoredKey``` to ignore nested elements [https://github.com/agourlay/cornichon/issues/15] but I do not like the fact that the overloading of ```body_field``` is gone.

WDYT?
 