### PR TITLE
add helper to query GQL

### DIFF
--- a/src/main/scala/com/github/agourlay/cornichon/http/HttpDsl.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/HttpDsl.scala
@@ -11,6 +11,7 @@ import com.github.agourlay.cornichon.http.HttpAssertions._
 import com.github.agourlay.cornichon.http.HttpEffects._
 import com.github.agourlay.cornichon.json.CornichonJson._
 import com.github.agourlay.cornichon.json.JsonPath
+import sangria.ast.Document
 
 import scala.concurrent.duration._
 
@@ -32,7 +33,7 @@ trait HttpDsl extends Dsl {
       case Patch(url, payload, params, headers)      ⇒ http.Patch(url, payload, params, headers)(s)
       case OpenSSE(url, takeWithin, params, headers) ⇒ http.OpenSSE(url, takeWithin, params, headers)(s)
       case OpenWS(url, takeWithin, params, headers)  ⇒ http.OpenWS(url, takeWithin, params, headers)(s)
-      case QueryGQL(url, params, headers)            ⇒ http.Get(url, params, headers)(s)
+      case q: QueryGQL                               ⇒ http.Post(q.url, q.gqlBody(), q.params, q.headers)(s)
     }
   )
 
@@ -45,7 +46,7 @@ trait HttpDsl extends Dsl {
   def open_sse(url: String, takeWithin: FiniteDuration) = OpenSSE(url, takeWithin, Seq.empty, Seq.empty)
   def open_ws(url: String, takeWithin: FiniteDuration) = OpenWS(url, takeWithin, Seq.empty, Seq.empty)
 
-  def query_gql(url: String) = QueryGQL(url, Seq.empty, Seq.empty)
+  def query_gql(url: String) = QueryGQL(url, "", Seq.empty, Seq.empty, Document(List.empty))
 
   val root = JsonPath.root
 

--- a/src/main/scala/com/github/agourlay/cornichon/http/HttpDsl.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/HttpDsl.scala
@@ -32,6 +32,7 @@ trait HttpDsl extends Dsl {
       case Patch(url, payload, params, headers)      ⇒ http.Patch(url, payload, params, headers)(s)
       case OpenSSE(url, takeWithin, params, headers) ⇒ http.OpenSSE(url, takeWithin, params, headers)(s)
       case OpenWS(url, takeWithin, params, headers)  ⇒ http.OpenWS(url, takeWithin, params, headers)(s)
+      case QueryGQL(url, params, headers)            ⇒ http.Get(url, params, headers)(s)
     }
   )
 
@@ -43,6 +44,8 @@ trait HttpDsl extends Dsl {
 
   def open_sse(url: String, takeWithin: FiniteDuration) = OpenSSE(url, takeWithin, Seq.empty, Seq.empty)
   def open_ws(url: String, takeWithin: FiniteDuration) = OpenWS(url, takeWithin, Seq.empty, Seq.empty)
+
+  def query_gql(url: String) = QueryGQL(url, Seq.empty, Seq.empty)
 
   val root = JsonPath.root
 

--- a/src/main/scala/com/github/agourlay/cornichon/http/HttpEffects.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/HttpEffects.scala
@@ -1,6 +1,7 @@
 package com.github.agourlay.cornichon.http
 
 import com.github.agourlay.cornichon.dsl.Dsl._
+import com.github.agourlay.cornichon.json.CornichonJson._
 import sangria.ast.Document
 import sangria.renderer.QueryRenderer
 
@@ -56,18 +57,6 @@ object HttpEffects {
 
   }
 
-  case class QueryGQL(url: String, params: Seq[(String, String)], headers: Seq[(String, String)]) extends HttpRequest {
-    val name = "Query GQL"
-
-    def withParams(params: (String, String)*) = copy(params = params)
-    def withHeaders(headers: (String, String)*) = copy(headers = headers)
-    def withQuery(query: Document) = {
-      val queryDoc = query.source.getOrElse(QueryRenderer.render(query, QueryRenderer.Pretty))
-      val allParams = params :+ ("query" → queryDoc)
-      copy(params = allParams)
-    }
-  }
-
   sealed trait HttpRequestWithPayload extends HttpRequest {
     def payload: String
 
@@ -95,6 +84,31 @@ object HttpEffects {
     def withParams(params: (String, String)*) = copy(params = params)
     def withHeaders(headers: (String, String)*) = copy(headers = headers)
   }
+
+  case class QueryGQL(url: String, payload: String, params: Seq[(String, String)], headers: Seq[(String, String)],
+      query: Document, operationName: Option[String] = None, variables: Option[Map[String, String]] = None) extends HttpRequestWithPayload {
+    val name = "Query GQL"
+
+    def withParams(params: (String, String)*) = copy(params = params)
+    def withHeaders(headers: (String, String)*) = copy(headers = headers)
+
+    //GQL builder
+    def withQuery(query: Document) = copy(query = query)
+    def withOperationName(operationName: String) = copy(operationName = Some(operationName))
+    def withVariables(newVariables: (String, String)*) = copy(variables = variables.map(_ ++ newVariables))
+    def gqlBody() = {
+
+      import org.json4s.Extraction
+
+      implicit val formats = org.json4s.DefaultFormats
+
+      val queryDoc = query.source.getOrElse(QueryRenderer.render(query, QueryRenderer.Pretty))
+      val newPayload = GqlPayload(queryDoc, operationName, variables)
+      prettyPrint(Extraction.decompose(newPayload))
+    }
+  }
+
+  private case class GqlPayload(query: String, operationName: Option[String], variables: Option[Map[String, String]])
 
   sealed trait HttpRequestStreamed extends HttpRequest {
     def takeWithin: FiniteDuration

--- a/src/main/scala/com/github/agourlay/cornichon/http/HttpEffects.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/HttpEffects.scala
@@ -1,6 +1,8 @@
 package com.github.agourlay.cornichon.http
 
 import com.github.agourlay.cornichon.dsl.Dsl._
+import sangria.ast.Document
+import sangria.renderer.QueryRenderer
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -52,6 +54,18 @@ object HttpEffects {
     def withParams(params: (String, String)*) = copy(params = params)
     def withHeaders(headers: (String, String)*) = copy(headers = headers)
 
+  }
+
+  case class QueryGQL(url: String, params: Seq[(String, String)], headers: Seq[(String, String)]) extends HttpRequest {
+    val name = "Query GQL"
+
+    def withParams(params: (String, String)*) = copy(params = params)
+    def withHeaders(headers: (String, String)*) = copy(headers = headers)
+    def withQuery(query: Document) = {
+      val queryDoc = query.source.getOrElse(QueryRenderer.render(query, QueryRenderer.Pretty))
+      val allParams = params :+ ("query" → queryDoc)
+      copy(params = allParams)
+    }
   }
 
   sealed trait HttpRequestWithPayload extends HttpRequest {


### PR DESCRIPTION
Add helper to query GQL endpoints, ```query``` is  Sangria doc, so the sangria macro must be used.

This could be used like

```scala
When I query_gql("url").withQuery(
          graphql"""
            query MyQuery {
              channels {
                results {
                  key
                  roles
                }
              }
            }
          """
        )
```

@OlegIlyenko WDYT about a helper like this in cornichon ? 