### PR TITLE
Improved unicode character handling in databale parser

### DIFF
--- a/src/main/scala/com/github/agourlay/cornichon/core/Errors.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/core/Errors.scala
@@ -9,6 +9,8 @@ import scala.util.control.NoStackTrace
 
 trait CornichonError extends Exception with NoStackTrace {
   def msg: String
+
+  override def getMessage = msg
 }
 
 object CornichonError {

--- a/src/main/scala/com/github/agourlay/cornichon/dsl/DataTable.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/dsl/DataTable.scala
@@ -41,7 +41,7 @@ class DataTableParser(val input: ParserInput) extends Parser with StringHeaderPa
 
   val WhiteSpace = CharPredicate("\u0009\u0020")
 
-  def Spaces = rule { zeroOrMore(WhiteSpace) }
+  def Spaces = rule { quiet(zeroOrMore(WhiteSpace)) }
 
   def Separator = rule { Spaces ~ delimeter ~ Spaces }
 
@@ -68,7 +68,7 @@ case class Row(fields: Seq[Json])
 trait StringHeaderParserSupport extends StringBuilding {
   this: Parser ⇒
 
-  def delims : CharPredicate
+  def delims: CharPredicate
 
   def HeaderValue = rule {
     atomic(clearSB() ~ Characters ~ push(sb.toString) ~> (_.trim))

--- a/src/main/scala/com/github/agourlay/cornichon/dsl/DataTable.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/dsl/DataTable.scala
@@ -20,27 +20,28 @@ object DataTableParser {
   }
 }
 
-class DataTableParser(val input: ParserInput) extends Parser {
-
-  val delimeter = '|'
+class DataTableParser(val input: ParserInput) extends Parser with StringHeaderParserSupport {
+  val delimeter = CharPredicate('|')
 
   def dataTableRule = rule {
-    optional(NL) ~ HeaderRule ~ NL ~ oneOrMore(RowRule).separatedBy(NL) ~ optional(NL) ~ EOI ~> DataTable
+    zeroOrMore(NL) ~ HeaderRule ~ NL ~ oneOrMore(RowRule).separatedBy(NL) ~ zeroOrMore(NL) ~ EOI ~> DataTable
   }
 
-  def HeaderRule = rule { Separator ~ oneOrMore(HeaderTXT).separatedBy(Separator) ~ Separator ~> Headers }
+  def HeaderRule = rule { Separator ~ oneOrMore(HeaderValue).separatedBy(Separator) ~ Separator ~> Headers }
 
   def RowRule = rule { Separator ~ oneOrMore(TXT).separatedBy(Separator) ~ Separator ~> (x ⇒ Row(x.map(parseString(_).fold(e ⇒ throw e, identity)))) }
 
-  val delims = s"$delimeter\r\n"
+  val delims = CharPredicate(delimeter, '\r', '\n')
 
-  def HeaderTXT = rule(capture(oneOrMore(CharPredicate.Visible -- delims)))
+  def TXT = rule { capture(oneOrMore(ContentsChar)) }
 
-  def TXT = rule(capture(oneOrMore(CharPredicate.Printable -- delims)))
+  def ContentsChar = rule { !delims ~ ANY }
 
   def NL = rule { Spaces ~ optional('\r') ~ '\n' ~ Spaces }
 
-  def Spaces = rule { zeroOrMore(' ') }
+  val WhiteSpace = CharPredicate("\u0009\u0020")
+
+  def Spaces = rule { zeroOrMore(WhiteSpace) }
 
   def Separator = rule { Spaces ~ delimeter ~ Spaces }
 
@@ -63,3 +64,32 @@ case class DataTable(headers: Headers, rows: Seq[Row]) {
 
 case class Headers(fields: Seq[String])
 case class Row(fields: Seq[Json])
+
+trait StringHeaderParserSupport extends StringBuilding {
+  this: Parser ⇒
+
+  def delims : CharPredicate
+
+  def HeaderValue = rule {
+    atomic(clearSB() ~ Characters ~ push(sb.toString) ~> (_.trim))
+  }
+
+  def Characters = rule { oneOrMore(NormalChar | '\\' ~ EscapedChar) }
+
+  val Backslash = CharPredicate('\\')
+
+  def NormalChar = rule { !(delims | Backslash) ~ ANY ~ appendSB() }
+
+  def EscapedChar = rule {
+    Backslash ~ appendSB() |
+      'b' ~ appendSB('\b') |
+      'f' ~ appendSB('\f') |
+      'n' ~ appendSB('\n') |
+      'r' ~ appendSB('\r') |
+      't' ~ appendSB('\t') |
+      '|' ~ appendSB('|') |
+      Unicode ~> { code ⇒ sb.append(code.asInstanceOf[Char]); () }
+  }
+
+  def Unicode = rule { 'u' ~ capture(4 times CharPredicate.HexDigit) ~> (Integer.parseInt(_, 16)) }
+}

--- a/src/main/scala/com/github/agourlay/cornichon/dsl/DslErrors.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/dsl/DslErrors.scala
@@ -5,7 +5,7 @@ import com.github.agourlay.cornichon.core.CornichonError
 sealed trait DslError extends CornichonError
 
 case class DataTableError(error: Throwable, input: String) extends DslError {
-  val msg = s"error thrown ${error.getMessage} while parsing data table $input"
+  val msg = s"error thrown '${error.getMessage}' while parsing data table $input"
 }
 
 case class DataTableParseError(msg: String) extends DslError


### PR DESCRIPTION
I noticed an issue in the parser: it was unable to handle unicode characters. `CharPredicate.Printable` and `CharPredicate.Visible` do not do the trick unfortunately. 

In this PR I treat JSON values generically (JSON parser takes care of them), but I implemented  a special parsing logic for header strings (since things like escaping need to be considered) 