### PR TITLE
HTTP mock

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ libraryDependencies ++= {
   val ficusV = "1.1.2"
   Seq(
      "com.typesafe.akka"   %% "akka-http-core"         % akkaHttpV
+    ,"com.typesafe.akka"   %% "akka-http-experimental" % akkaHttpV
     ,"de.heikoseeberger"   %% "akka-sse"               % akkaSseV
     ,"org.typelevel"       %% "cats-macros"            % catsV
     ,"org.typelevel"       %% "cats-core"              % catsV
@@ -66,7 +67,6 @@ libraryDependencies ++= {
     ,"io.circe"            %% "circe-parser"           % circeVersion
     //,"io.circe"            %% "circe-optics"           % circeVersion  Remove if cursors are used instead or lenses for JsonPath.
     ,"de.heikoseeberger"   %% "akka-http-circe"        % akkaHttpCirce   % "test"
-    ,"com.typesafe.akka"   %% "akka-http-experimental" % akkaHttpV       % "test"
     ,"com.ironcorelabs"    %% "cats-scalatest"         % catsScalaTest   % "test"
   )
 }

--- a/src/main/scala/com/github/agourlay/cornichon/CornichonFeature.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/CornichonFeature.scala
@@ -2,6 +2,7 @@ package com.github.agourlay.cornichon
 
 import java.util.concurrent.Executors
 
+import akka.stream.ActorMaterializer
 import com.github.agourlay.cornichon.core._
 import com.github.agourlay.cornichon.dsl.Dsl
 import com.github.agourlay.cornichon.http.client.HttpClient
@@ -26,7 +27,7 @@ trait CornichonFeature extends HttpDsl with JsonDsl with Dsl with ScalatestInteg
   protected var beforeEachScenario: Seq[Step] = Nil
   protected var afterEachScenario: Seq[Step] = Nil
 
-  private lazy val (globalClient, ec) = globalRuntime
+  private lazy val (globalClient, ec, _, _) = globalRuntime
   private lazy val engine = Engine.withStepTitleResolver(resolver, ec)
 
   lazy val requestTimeout = config.requestTimeout
@@ -74,6 +75,7 @@ private object CornichonFeature {
   import com.github.agourlay.cornichon.http.client.AkkaHttpClient
 
   implicit private lazy val system = ActorSystem("cornichon-actor-system")
+  implicit private lazy val mat = ActorMaterializer()
   implicit private lazy val ec = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool)
 
   private lazy val client: HttpClient = new AkkaHttpClient()
@@ -89,13 +91,14 @@ private object CornichonFeature {
       if (safePassInRow.get() == 3) {
         client.shutdown().map { _ ⇒
           ec.shutdown()
+          mat.shutdown()
           system.terminate()
         }
       }
     } else if (safePassInRow.get() > 0) safePassInRow.decrementAndGet()
   }
 
-  lazy val globalRuntime = (client, ec)
+  lazy val globalRuntime = (client, ec, system, mat)
   def reserveGlobalRuntime(): Unit = registeredUsage.incrementAndGet()
   def releaseGlobalRuntime(): Unit = registeredUsage.decrementAndGet()
 }

--- a/src/main/scala/com/github/agourlay/cornichon/core/Session.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/core/Session.scala
@@ -25,9 +25,13 @@ case class Session(content: Map[String, Vector[String]]) {
 
   }
 
-  def get(key: String, stackingIndice: Option[Int] = None): String = getOpt(key, stackingIndice).getOrElse(throw KeyNotFoundInSession(key, this))
+  def get(key: String, stackingIndice: Option[Int] = None): String =
+    getOpt(key, stackingIndice).getOrElse(throw KeyNotFoundInSession(key, stackingIndice, this))
 
-  def getXor(key: String, stackingIndice: Option[Int] = None) = Xor.fromOption(getOpt(key, stackingIndice), KeyNotFoundInSession(key, this))
+  def get(sessionKey: SessionKey): String = get(sessionKey.name, sessionKey.index)
+
+  def getXor(key: String, stackingIndice: Option[Int] = None) =
+    Xor.fromOption(getOpt(key, stackingIndice), KeyNotFoundInSession(key, stackingIndice, this))
 
   def getJsonXor(key: String, stackingIndice: Option[Int] = None, path: String = JsonPath.root): Xor[CornichonError, Json] =
     for {
@@ -78,10 +82,14 @@ object Session {
   }
 }
 
+case class SessionKey(name: String, index: Option[Int] = None) {
+  def atIndex(index: Int) = copy(index = Some(index))
+}
+
 case class EmptyKeyException(s: Session) extends CornichonError {
   val msg = s"key value can not be empty - session is \n${s.prettyPrint}"
 }
 
-case class KeyNotFoundInSession(key: String, s: Session) extends CornichonError {
-  val msg = s"key '$key' can not be found in session \n${s.prettyPrint}"
+case class KeyNotFoundInSession(key: String, indice: Option[Int], s: Session) extends CornichonError {
+  val msg = s"key '$key'${indice.fold("")(i ⇒ s" at indice '$i'")} can not be found in session \n${s.prettyPrint}"
 }

--- a/src/main/scala/com/github/agourlay/cornichon/dsl/BlockScopedResource.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/dsl/BlockScopedResource.scala
@@ -1,0 +1,19 @@
+package com.github.agourlay.cornichon.dsl
+
+import com.github.agourlay.cornichon.core.Session
+
+import scala.concurrent.Future
+
+trait BlockScopedResource {
+
+  val sessionTarget: String
+
+  val openingTitle: String
+  val closingTitle: String
+
+  def startResource(): Future[Unit]
+
+  def stopResource(): Future[Unit]
+
+  def resourceResults(): Session
+}

--- a/src/main/scala/com/github/agourlay/cornichon/dsl/Dsl.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/dsl/Dsl.scala
@@ -105,7 +105,7 @@ trait Dsl extends ShowInstances {
     effect = s ⇒ s.removeKey(key)
   )
 
-  def session_value(key: String, indice: Option[Int] = None) = SessionAssertion(key, indice, resolver)
+  def session_value(key: String) = SessionAssertion(resolver, key)
 
   def show_session = DebugStep(s ⇒ s"Session content is\n${s.prettyPrint}")
 
@@ -132,7 +132,7 @@ object Dsl {
     )
   }
 
-  def from_session_step[A: Show](key: String, expected: Session ⇒ A, mapValue: (Session, String) ⇒ A, title: String) =
+  def from_session_step[A: Show](key: SessionKey, expected: Session ⇒ A, mapValue: (Session, String) ⇒ A, title: String) =
     AssertStep(
       title,
       s ⇒ GenericAssertion(
@@ -141,7 +141,7 @@ object Dsl {
       )
     )
 
-  def from_session_detail_step[A: Show](key: String, expected: Session ⇒ A, mapValue: (Session, String) ⇒ (A, A ⇒ String), title: String) =
+  def from_session_detail_step[A: Show](key: SessionKey, expected: Session ⇒ A, mapValue: (Session, String) ⇒ (A, A ⇒ String), title: String) =
     AssertStep(
       title,
       s ⇒ {

--- a/src/main/scala/com/github/agourlay/cornichon/dsl/SessionAssertion.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/dsl/SessionAssertion.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.dsl
 
+import com.github.agourlay.cornichon.core.SessionKey
 import com.github.agourlay.cornichon.steps.regular.{ AssertStep, CustomMessageAssertion, GenericAssertion }
 import com.github.agourlay.cornichon.dsl.SessionAssertionErrors._
 import com.github.agourlay.cornichon.json.JsonAssertions.JsonAssertion
@@ -7,10 +8,13 @@ import com.github.agourlay.cornichon.resolver.Resolver
 import com.github.agourlay.cornichon.util.ShowInstances._
 
 case class SessionAssertion(
+    private val resolver: Resolver,
     private val key: String,
-    private val indice: Option[Int] = None,
-    private val resolver: Resolver
+    private val indice: Option[Int] = None
 ) {
+
+  def atIndex(indice: Int) = copy(indice = Some(indice))
+
   def is(expected: String) = AssertStep(
     title = s"session key '$key' is '$expected'",
     action = s ⇒ GenericAssertion(expected, s.get(key, indice))
@@ -34,6 +38,6 @@ case class SessionAssertion(
     action = s ⇒ CustomMessageAssertion(None, s.getOpt(key, indice), keyIsPresentError(key))
   )
 
-  def asJson = JsonAssertion(resolver, key)
+  def asJson = JsonAssertion(resolver, SessionKey(key))
 
 }

--- a/src/main/scala/com/github/agourlay/cornichon/http/HttpAssertions.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/HttpAssertions.scala
@@ -62,12 +62,8 @@ object HttpAssertions {
       action = s ⇒ GenericAssertion(expected = count, actual = s.get(s"$name$nbReceivedCallsSuffix").toInt)
     )
 
-    def first_received_body = received_body_nb(1)
+    def received_requests =
+      JsonAssertion(resolver, SessionKey(s"$name$receivedBodiesSuffix"), prettySessionKeyTitle = Some(s"HTTP mock server '$name' received requests"))
 
-    def received_body_nb(nb: Int) = {
-      val physicalIndice = nb - 1
-      val nbLabel = if (physicalIndice == 0) "first" else physicalIndice.toString
-      JsonAssertion(resolver, SessionKey(s"$name$receivedBodiesSuffix").atIndex(physicalIndice), Some(s"HTTP mock server '$name' $nbLabel received body"))
-    }
   }
 }

--- a/src/main/scala/com/github/agourlay/cornichon/http/HttpAssertions.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/HttpAssertions.scala
@@ -59,10 +59,7 @@ object HttpAssertions {
   case class HttpListen(name: String, resolver: Resolver) {
     def received_calls(count: Int) = AssertStep(
       title = s"HTTP mock server '$name' received '$count' calls",
-      action = s ⇒ GenericAssertion(
-      expected = count,
-      actual = s.get(s"$name$nbReceivedCallsSuffix").toInt
-    )
+      action = s ⇒ GenericAssertion(expected = count, actual = s.get(s"$name$nbReceivedCallsSuffix").toInt)
     )
 
     def first_received_body = received_body_nb(1)

--- a/src/main/scala/com/github/agourlay/cornichon/http/server/AkkaHttpServer.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/server/AkkaHttpServer.scala
@@ -1,0 +1,23 @@
+package com.github.agourlay.cornichon.http.server
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+class AkkaHttpServer(port: Int, requestHandler: HttpRequest ⇒ HttpResponse)(implicit system: ActorSystem, mat: ActorMaterializer, executionContext: ExecutionContext) extends HttpServer {
+
+  // FIXME var :(
+  var bindingFuture: Future[Http.ServerBinding] = _
+
+  def startServer = {
+    val serverSource = Http().bind(interface = "localhost", port)
+    bindingFuture = serverSource.to(Sink.foreach { _ handleWithSyncHandler requestHandler }).run()
+    bindingFuture.map(_ ⇒ ())
+  }
+
+  def stopServer = bindingFuture.flatMap(_.unbind())
+}

--- a/src/main/scala/com/github/agourlay/cornichon/http/server/HttpMockServerResource.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/server/HttpMockServerResource.scala
@@ -1,0 +1,44 @@
+package com.github.agourlay.cornichon.http.server
+
+import com.github.agourlay.cornichon.CornichonFeature
+import com.github.agourlay.cornichon.core.Session
+import com.github.agourlay.cornichon.dsl.BlockScopedResource
+import com.github.agourlay.cornichon.http.server.HttpMockServerResource.SessionKeys._
+
+case class HttpMockServerResource(label: String, port: Int) extends BlockScopedResource {
+  val sessionTarget: String = label
+  val openingTitle: String = s"Starting HTTP mock server '$label' listening on port '$port'"
+  val closingTitle: String = s"Shutting down HTTP mock server '$label'"
+
+  // FIXME vars :(
+  var akkaServer: AkkaHttpServer = _
+  var mockRequestHandler: MockRequestHandler = _
+
+  def startResource() = {
+    CornichonFeature.reserveGlobalRuntime()
+    implicit val (_, ec, system, mat) = CornichonFeature.globalRuntime
+    mockRequestHandler = new MockRequestHandler()
+    akkaServer = new AkkaHttpServer(port, mockRequestHandler.requestHandler)
+    akkaServer.startServer
+  }
+
+  def stopResource() = {
+    CornichonFeature.releaseGlobalRuntime()
+    akkaServer.stopServer
+  }
+
+  def resourceResults() = {
+    val requests = mockRequestHandler.getRecordedRequests
+    val requestsCount = requests.size
+    val sessionWithBodies = requests.foldLeft(Session.newSession)((s, r) ⇒
+      s.addValue(s"$sessionTarget$receivedBodiesSuffix", r.body.getOrElse("")))
+    sessionWithBodies.addValue(s"$sessionTarget$nbReceivedCallsSuffix", requestsCount.toString)
+  }
+}
+
+object HttpMockServerResource {
+  object SessionKeys {
+    val nbReceivedCallsSuffix = "-nb-received-calls"
+    val receivedBodiesSuffix = "-received-bodies"
+  }
+}

--- a/src/main/scala/com/github/agourlay/cornichon/http/server/HttpServer.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/server/HttpServer.scala
@@ -1,0 +1,10 @@
+package com.github.agourlay.cornichon.http.server
+
+import scala.concurrent.Future
+
+trait HttpServer {
+
+  def startServer: Future[Unit]
+  def stopServer: Future[Unit]
+
+}

--- a/src/main/scala/com/github/agourlay/cornichon/http/server/MockRequestHandler.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/server/MockRequestHandler.scala
@@ -1,0 +1,56 @@
+package com.github.agourlay.cornichon.http.server
+
+import akka.http.scaladsl.client.RequestBuilding._
+import akka.http.scaladsl.coding.Gzip
+import akka.http.scaladsl.model.HttpMethods._
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
+import com.github.agourlay.cornichon.http.{ HttpMethod ⇒ CornichonHttpMethod, HttpMethods ⇒ CornichonHttpMethods, HttpRequest ⇒ CornichonHttpRequest }
+import com.github.agourlay.cornichon.http.BodyInput._
+import com.github.agourlay.cornichon.util.ShowInstances._
+
+import scala.concurrent.ExecutionContext
+
+class MockRequestHandler(implicit system: ActorMaterializer, executionContext: ExecutionContext) {
+
+  private val requests = new scala.collection.mutable.ArrayBuffer[CornichonHttpRequest[String]]
+
+  def getRecordedRequests = requests.toVector
+
+  val requestHandler: HttpRequest ⇒ HttpResponse = {
+    case r @ HttpRequest(POST, _, _, _, _) ⇒
+      saveRequest(r)
+      HttpResponse(201)
+
+    case r: HttpRequest ⇒
+      saveRequest(r)
+      HttpResponse(200)
+  }
+
+  def httpMethodMapper(method: HttpMethod): CornichonHttpMethod = method match {
+    case Delete.method  ⇒ CornichonHttpMethods.DELETE
+    case Get.method     ⇒ CornichonHttpMethods.GET
+    case Head.method    ⇒ CornichonHttpMethods.HEAD
+    case Options.method ⇒ CornichonHttpMethods.OPTIONS
+    case Patch.method   ⇒ CornichonHttpMethods.PATCH
+    case Post.method    ⇒ CornichonHttpMethods.POST
+    case Put.method     ⇒ CornichonHttpMethods.PUT
+  }
+
+  //FIXME Don't look to close here...
+  def saveRequest(akkaReq: HttpRequest) = {
+    Unmarshal(Gzip.decode(akkaReq)).to[String].map { decodeBody: String ⇒
+      val req = CornichonHttpRequest[String](
+        method = httpMethodMapper(akkaReq.method),
+        url = akkaReq.uri.path.toString(),
+        body = Some(decodeBody),
+        params = Seq.empty,
+        headers = Seq.empty
+      )
+      synchronized {
+        requests.+=(req)
+      }
+    }
+  }
+}

--- a/src/main/scala/com/github/agourlay/cornichon/json/JsonAssertions.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/json/JsonAssertions.scala
@@ -1,7 +1,7 @@
 package com.github.agourlay.cornichon.json
 
 import cats.Show
-import com.github.agourlay.cornichon.core.Session
+import com.github.agourlay.cornichon.core.{ Session, SessionKey }
 import com.github.agourlay.cornichon.dsl.Dsl._
 import com.github.agourlay.cornichon.json.JsonAssertionErrors._
 import com.github.agourlay.cornichon.json.JsonDiff.Diff
@@ -35,14 +35,14 @@ object JsonAssertions {
 
   case class JsonAssertion(
       private val resolver: Resolver,
-      private val sessionKey: String,
+      private val sessionKey: SessionKey,
       private val prettySessionKeyTitle: Option[String] = None,
       private val jsonPath: String = JsonPath.root,
       private val ignoredKeys: Seq[String] = Seq.empty,
       private val whitelist: Boolean = false
   ) {
 
-    private val target = prettySessionKeyTitle.getOrElse(sessionKey)
+    private val target = prettySessionKeyTitle.getOrElse(sessionKey.name)
 
     def path(path: String): JsonAssertion = copy(jsonPath = path)
 
@@ -139,7 +139,7 @@ object JsonAssertions {
   }
 
   case class JsonArrayAssertion(
-      private val sessionKey: String,
+      private val sessionKey: SessionKey,
       private val jsonPath: String,
       private val ordered: Boolean,
       private val ignoredEachKeys: Seq[String],
@@ -263,7 +263,7 @@ object JsonAssertions {
   }
 
   private def body_array_transform[A: Show](
-    sessionKey: String,
+    sessionKey: SessionKey,
     arrayExtractor: (Session, String) ⇒ List[Json],
     mapFct: (Session, List[Json]) ⇒ A,
     title: String,

--- a/src/main/scala/com/github/agourlay/cornichon/resolver/Resolver.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/resolver/Resolver.scala
@@ -25,10 +25,11 @@ class Resolver(extractors: Map[String, Mapper]) {
 
   def resolvePlaceholder(ph: Placeholder)(session: Session): Xor[CornichonError, String] =
     builtInPlaceholders.lift(ph.key).map(right).getOrElse {
-      val other = ph.key
-      (session.getOpt(other, ph.index), extractors.get(other)) match {
-        case (Some(v), Some(m))           ⇒ left(AmbiguousKeyDefinition(other))
-        case (None, None)                 ⇒ left(KeyNotFoundInSession(other, session))
+      val otherKeyName = ph.key
+      val otherKeyIndice = ph.index
+      (session.getOpt(otherKeyName, otherKeyIndice), extractors.get(otherKeyName)) match {
+        case (Some(v), Some(m))           ⇒ left(AmbiguousKeyDefinition(otherKeyName))
+        case (None, None)                 ⇒ left(KeyNotFoundInSession(otherKeyName, otherKeyIndice, session))
         case (Some(valueInSession), None) ⇒ right(valueInSession)
         case (None, Some(mapper))         ⇒ applyMapper(mapper, session, ph)
       }

--- a/src/main/scala/com/github/agourlay/cornichon/steps/wrapped/WithBlockScopedResource.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/steps/wrapped/WithBlockScopedResource.scala
@@ -1,0 +1,39 @@
+package com.github.agourlay.cornichon.steps.wrapped
+
+import cats.data.Xor._
+import com.github.agourlay.cornichon.core.Done._
+import com.github.agourlay.cornichon.core._
+import com.github.agourlay.cornichon.dsl.BlockScopedResource
+
+import scala.concurrent.ExecutionContext
+
+//TODO chain futures once https://github.com/agourlay/cornichon/issues/80
+case class WithBlockScopedResource(nested: Vector[Step], resource: BlockScopedResource) extends WrapperStep {
+
+  val title = resource.openingTitle
+
+  override def run(engine: Engine)(initialRunState: RunState)(implicit ec: ExecutionContext) = {
+    resource.startResource()
+    val resourcedRunState = initialRunState.withSteps(nested).resetLogs.goDeeper
+    val (resourcedState, resourcedRes) = engine.runSteps(resourcedRunState)
+
+    val nestedLogs = resourcedState.logs
+    val initialDepth = initialRunState.depth
+
+    val (fullLogs, xor) = resourcedRes.fold(
+      failedStep ⇒ {
+        val failureLogs = failedTitleLog(initialDepth) +: nestedLogs :+ FailureLogInstruction(resource.closingTitle, initialDepth)
+        (failureLogs, left(failedStep))
+      },
+      done ⇒ {
+        val successLogs = successTitleLog(initialDepth) +: nestedLogs :+ SuccessLogInstruction(resource.closingTitle, initialDepth, None)
+        (successLogs, rightDone)
+      }
+    )
+
+    resource.stopResource()
+    val resourceResults = resource.resourceResults()
+    val completeSession = resourcedState.session.merge(resourceResults)
+    (initialRunState.withSession(completeSession).appendLogs(fullLogs), xor)
+  }
+}

--- a/src/test/scala/com/github/agourlay/cornichon/examples/MockServerExample.scala
+++ b/src/test/scala/com/github/agourlay/cornichon/examples/MockServerExample.scala
@@ -55,19 +55,34 @@ class MockServerExample extends CornichonFeature {
 
       And assert httpListen("awesome-server").received_calls(2)
 
-      And assert httpListen("awesome-server").first_received_body.is(
+      And assert httpListen("awesome-server").received_requests.is(
         """
-          {
-            "name": "Batman",
-            "realName": "Bruce Wayne",
-            "hasSuperpowers": false
-          }
+          [
+            {
+              "body" : {
+                "name" : "Batman",
+                "realName" : "Bruce Wayne",
+                "hasSuperpowers" : false
+              },
+              "url" : "/",
+              "verb" : "POST"
+            },
+            {
+              "body" : {
+                "name" : "Superman",
+                "realName" : "Clark Kent",
+                "hasSuperpowers" : true
+              },
+              "url" : "/",
+              "verb" : "POST"
+            }
+          ]
         """
       )
 
-      And assert httpListen("awesome-server").first_received_body.path("name").is("Batman")
+      And assert httpListen("awesome-server").received_requests.path("$[0].body.name").is("Batman")
 
-      And assert httpListen("awesome-server").received_body_nb(2).is(
+      And assert httpListen("awesome-server").received_requests.path("$[1].body").is(
         """
         {
           "name": "Superman",

--- a/src/test/scala/com/github/agourlay/cornichon/examples/MockServerExample.scala
+++ b/src/test/scala/com/github/agourlay/cornichon/examples/MockServerExample.scala
@@ -17,10 +17,10 @@ class MockServerExample extends CornichonFeature {
     }
 
     Scenario("Counters valid under concurrent requests") {
-      HttpListenTo(label = "awesome-server", port = 9092) {
+      HttpListenTo(label = "awesome-server", port = 9091) {
         Concurrently(2, 10.seconds) {
           Repeat(10) {
-            When I get("http://localhost:9092/")
+            When I get("http://localhost:9091/")
           }
         }
       }
@@ -28,8 +28,8 @@ class MockServerExample extends CornichonFeature {
     }
 
     Scenario("Reply to POST request with 201 and assert on received bodies") {
-      HttpListenTo(label = "awesome-server", port = 9091) {
-        When I post("http://localhost:9091/").withBody(
+      HttpListenTo(label = "awesome-server", port = 9092) {
+        When I post("http://localhost:9092/").withBody(
           """
           {
             "name": "Batman",
@@ -39,7 +39,7 @@ class MockServerExample extends CornichonFeature {
           """
         )
 
-        When I post("http://localhost:9091/").withBody(
+        When I post("http://localhost:9092/").withBody(
           """
           {
             "name": "Superman",
@@ -78,6 +78,22 @@ class MockServerExample extends CornichonFeature {
       )
 
       And I show_session
+    }
+
+    Scenario("httpListen blocks can be nested in one another") {
+      HttpListenTo(label = "first-server", port = 9093) {
+        HttpListenTo(label = "second-server", port = 9094) {
+          HttpListenTo(label = "third-server", port = 9095) {
+            When I get("http://localhost:9093/")
+            When I get("http://localhost:9094/")
+            When I get("http://localhost:9095/")
+          }
+        }
+      }
+      And assert httpListen("first-server").received_calls(1)
+      And assert httpListen("second-server").received_calls(1)
+      And assert httpListen("third-server").received_calls(1)
+
     }
 
   }

--- a/src/test/scala/com/github/agourlay/cornichon/examples/MockServerExample.scala
+++ b/src/test/scala/com/github/agourlay/cornichon/examples/MockServerExample.scala
@@ -29,7 +29,7 @@ class MockServerExample extends CornichonFeature {
 
     Scenario("Reply to POST request with 201 and assert on received bodies") {
       HttpListenTo(label = "awesome-server", port = 9092) {
-        When I post("http://localhost:9092/").withBody(
+        When I post("http://localhost:9092/heroes/batman").withBody(
           """
           {
             "name": "Batman",
@@ -39,7 +39,7 @@ class MockServerExample extends CornichonFeature {
           """
         )
 
-        When I post("http://localhost:9092/").withBody(
+        When I post("http://localhost:9092/heroes/superman").withBody(
           """
           {
             "name": "Superman",
@@ -64,7 +64,7 @@ class MockServerExample extends CornichonFeature {
                 "realName" : "Bruce Wayne",
                 "hasSuperpowers" : false
               },
-              "url" : "/",
+              "url" : "/heroes/batman",
               "verb" : "POST"
             },
             {
@@ -73,7 +73,7 @@ class MockServerExample extends CornichonFeature {
                 "realName" : "Clark Kent",
                 "hasSuperpowers" : true
               },
-              "url" : "/",
+              "url" : "/heroes/superman",
               "verb" : "POST"
             }
           ]

--- a/src/test/scala/com/github/agourlay/cornichon/examples/MockServerExample.scala
+++ b/src/test/scala/com/github/agourlay/cornichon/examples/MockServerExample.scala
@@ -1,0 +1,85 @@
+package com.github.agourlay.cornichon.examples
+
+import com.github.agourlay.cornichon.CornichonFeature
+import scala.concurrent.duration._
+
+class MockServerExample extends CornichonFeature {
+
+  lazy val feature = Feature("Cornichon feature mock server examples") {
+
+    Scenario("Assert number of received calls") {
+      HttpListenTo(label = "awesome-server", port = 9090) {
+        Repeat(10) {
+          When I get("http://localhost:9090/")
+        }
+      }
+      And assert httpListen("awesome-server").received_calls(10)
+    }
+
+    Scenario("Counters valid under concurrent requests") {
+      HttpListenTo(label = "awesome-server", port = 9092) {
+        Concurrently(2, 10.seconds) {
+          Repeat(10) {
+            When I get("http://localhost:9092/")
+          }
+        }
+      }
+      And assert httpListen("awesome-server").received_calls(20)
+    }
+
+    Scenario("Reply to POST request with 201 and assert on received bodies") {
+      HttpListenTo(label = "awesome-server", port = 9091) {
+        When I post("http://localhost:9091/").withBody(
+          """
+          {
+            "name": "Batman",
+            "realName": "Bruce Wayne",
+            "hasSuperpowers": false
+          }
+          """
+        )
+
+        When I post("http://localhost:9091/").withBody(
+          """
+          {
+            "name": "Superman",
+            "realName": "Clark Kent",
+            "hasSuperpowers": true
+          }
+          """
+        )
+
+        Then assert status.is(201)
+
+      }
+
+      And assert httpListen("awesome-server").received_calls(2)
+
+      And assert httpListen("awesome-server").first_received_body.is(
+        """
+          {
+            "name": "Batman",
+            "realName": "Bruce Wayne",
+            "hasSuperpowers": false
+          }
+        """
+      )
+
+      And assert httpListen("awesome-server").first_received_body.path("name").is("Batman")
+
+      And assert httpListen("awesome-server").received_body_nb(2).is(
+        """
+        {
+          "name": "Superman",
+          "realName": "Clark Kent",
+          "hasSuperpowers": true
+        }
+        """
+      )
+
+      And I show_session
+    }
+
+  }
+
+}

--- a/src/test/scala/com/github/agourlay/cornichon/resolver/ResolverSpec.scala
+++ b/src/test/scala/com/github/agourlay/cornichon/resolver/ResolverSpec.scala
@@ -91,7 +91,7 @@ class ResolverSpec extends WordSpec with Matchers with OptionValues with Propert
       "return ResolverError if placeholder not found" in {
         val session = Session.newSession.addValue("project-name", "cornichon")
         val content = "This project is named <project-new-name>"
-        resolver.fillPlaceholders(content)(session).leftValue should be(KeyNotFoundInSession("project-new-name", session))
+        resolver.fillPlaceholders(content)(session).leftValue should be(KeyNotFoundInSession("project-new-name", None, session))
       }
 
       "resolve two placeholders" in {
@@ -103,7 +103,7 @@ class ResolverSpec extends WordSpec with Matchers with OptionValues with Propert
       "return ResolverError for the first placeholder not found" in {
         val session = Session.newSession.addValues(Seq("project-name" → "cornichon", "taste" → "tasty"))
         val content = "This project is named <project-name> and is super <new-taste>"
-        resolver.fillPlaceholders(content)(session).leftValue should be(KeyNotFoundInSession("new-taste", session))
+        resolver.fillPlaceholders(content)(session).leftValue should be(KeyNotFoundInSession("new-taste", None, session))
       }
 
       "generate random uuid if <random-uuid>" in {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.1-SNASPHOT"
+version in ThisBuild := "0.9.1-SNAPSHOT"


### PR DESCRIPTION
This is a proof of concept for the HTTP mock feature described https://github.com/agourlay/cornichon/issues/83

Some important info:

- a bunch of TODO left for chaining properly ```Futures``` - https://github.com/agourlay/cornichon/issues/80 required
- a couple of ugly ```vars``` that could be replaced by full blown actor if necessary once concept validated
- so far only ```request count``` and ```request bodies``` DSL are present
- the httpListen DSL  was able to reuse to newly extracted ```JsonAssertion``` https://github.com/agourlay/cornichon/issues/86

@cneijenhuis If you like this I will release this in the 0.9.1 silently for you to play with. 

It will be released officially once: 
- everyone is happy with the design of the DSL/API
- the code is cleaned up from all the nasty stuff 👺 
