### PR TITLE
Add RegExpAssertion support

### DIFF
--- a/src/main/scala/com/github/agourlay/cornichon/json/JsonSteps.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/json/JsonSteps.scala
@@ -12,6 +12,8 @@ import com.github.agourlay.cornichon.steps.regular.assertStep._
 import com.github.agourlay.cornichon.util.Instances._
 import io.circe.{ Encoder, Json }
 
+import scala.util.matching.Regex
+
 object JsonSteps {
 
   case class JsonValuesStepBuilder(
@@ -90,6 +92,18 @@ object JsonSteps {
           val sessionValue = s.get(sessionKey)
           val subJson = resolveRunJsonPath(jsonPath, sessionValue, resolver)(s)
           StringContainsAssertion(subJson.show, expectedPart)
+        }
+      )
+    }
+
+    def regExpMatch(expectedRegex: Regex) = {
+      val baseTitle = if (jsonPath == JsonPath.root) s"$target mathes '$expectedRegex'" else s"$target's field '$jsonPath' matches '$expectedRegex'"
+      AssertStep(
+        title = jsonAssertionTitleBuilder(baseTitle, ignoredKeys, whitelist),
+        action = s ⇒ {
+          val sessionValue = s.get(sessionKey)
+          val subJson = resolveRunJsonPath(jsonPath, sessionValue, resolver)(s)
+          RegexAssertion(subJson.show, expectedRegex)
         }
       )
     }

--- a/src/main/scala/com/github/agourlay/cornichon/json/JsonSteps.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/json/JsonSteps.scala
@@ -96,8 +96,8 @@ object JsonSteps {
       )
     }
 
-    def regExpMatch(expectedRegex: Regex) = {
-      val baseTitle = if (jsonPath == JsonPath.root) s"$target mathes '$expectedRegex'" else s"$target's field '$jsonPath' matches '$expectedRegex'"
+    def matchesRegex(expectedRegex: Regex) = {
+      val baseTitle = if (jsonPath == JsonPath.root) s"$target matches '$expectedRegex'" else s"$target's field '$jsonPath' matches '$expectedRegex'"
       AssertStep(
         title = jsonAssertionTitleBuilder(baseTitle, ignoredKeys, whitelist),
         action = s ⇒ {

--- a/src/main/scala/com/github/agourlay/cornichon/steps/regular/assertStep/StringAssertion.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/steps/regular/assertStep/StringAssertion.scala
@@ -4,9 +4,11 @@ import cats.data.Validated._
 import cats.data._
 import com.github.agourlay.cornichon.core.{ CornichonError, Done }
 
+import scala.util.matching.Regex
+
 abstract class StringAssertion extends Assertion
 
-case class StringContainsAssertion(input: String, expectedPart: String) extends Assertion {
+case class StringContainsAssertion(input: String, expectedPart: String) extends StringAssertion {
   val validated: ValidatedNel[CornichonError, Done] =
     if (input.contains(expectedPart)) valid(Done) else invalidNel(StringContainsAssertionError(input, expectedPart))
 }
@@ -14,4 +16,16 @@ case class StringContainsAssertion(input: String, expectedPart: String) extends 
 case class StringContainsAssertionError(input: String, expectedPart: String) extends CornichonError {
   val baseErrorMessage = s"""expected string '$expectedPart' to be contained but it is not the case with value :
                 |$input""".stripMargin
+}
+
+case class RegexAssertion(input: String, expectedRegex: Regex) extends StringAssertion {
+  val validated: ValidatedNel[CornichonError, Done] = {
+    val matching = expectedRegex.findFirstIn(input)
+    if (matching.isDefined) valid(Done) else invalidNel(RegexAssertionError(input, expectedRegex))
+  }
+}
+
+case class RegexAssertionError(input: String, expectedRegex: Regex) extends CornichonError {
+  val baseErrorMessage = s"""expected regular expression '$expectedRegex' to be matched but it is not the case with value :
+                  |$input""".stripMargin
 }

--- a/src/test/scala/com/github/agourlay/cornichon/examples/superHeroes/SuperHeroesScenario.scala
+++ b/src/test/scala/com/github/agourlay/cornichon/examples/superHeroes/SuperHeroesScenario.scala
@@ -82,6 +82,10 @@ class SuperHeroesScenario extends CornichonFeature {
 
         Then assert body.path("city").containsString("Gotham")
 
+        Then assert body.path("city").regExpMatch(".*ham.*ty".r)
+
+        Then assert body.path("name").regExpMatch(".*man".r)
+
         Then assert body.path("country").isAbsent
 
         Then assert body.path("hasSuperpowers").is(false)
@@ -560,6 +564,8 @@ class SuperHeroesScenario extends CornichonFeature {
         Eventually(maxDuration = 3 seconds, interval = 10 milliseconds) {
 
           When I get("/superheroes/random").withParams("sessionId" → "<session-id>")
+
+          Then assert body.path("name").regExpMatch(".*man".r)
 
           Then assert body.ignoring("hasSuperpowers", "publisher").is(
             """

--- a/src/test/scala/com/github/agourlay/cornichon/examples/superHeroes/SuperHeroesScenario.scala
+++ b/src/test/scala/com/github/agourlay/cornichon/examples/superHeroes/SuperHeroesScenario.scala
@@ -82,9 +82,9 @@ class SuperHeroesScenario extends CornichonFeature {
 
         Then assert body.path("city").containsString("Gotham")
 
-        Then assert body.path("city").regExpMatch(".*ham.*ty".r)
+        Then assert body.path("city").matchesRegex(".*ham.*ty".r)
 
-        Then assert body.path("name").regExpMatch(".*man".r)
+        Then assert body.path("name").matchesRegex(".*man".r)
 
         Then assert body.path("country").isAbsent
 
@@ -565,7 +565,7 @@ class SuperHeroesScenario extends CornichonFeature {
 
           When I get("/superheroes/random").withParams("sessionId" → "<session-id>")
 
-          Then assert body.path("name").regExpMatch(".*man".r)
+          Then assert body.path("name").matchesRegex(".*man".r)
 
           Then assert body.ignoring("hasSuperpowers", "publisher").is(
             """

--- a/src/test/scala/com/github/agourlay/cornichon/steps/regular/assertStep/StringAssertionSpec.scala
+++ b/src/test/scala/com/github/agourlay/cornichon/steps/regular/assertStep/StringAssertionSpec.scala
@@ -1,0 +1,37 @@
+package com.github.agourlay.cornichon.steps.regular.assertStep
+
+import cats.scalatest.{ ValidatedMatchers, ValidatedValues }
+import com.github.agourlay.cornichon.util.Instances._
+import org.scalatest.{ Matchers, WordSpec }
+
+class StringAssertionSpec extends WordSpec
+    with Matchers
+    with ValidatedMatchers
+    with ValidatedValues {
+
+  "StringAssertion" must {
+
+    "StringContainsAssertion" must {
+      "valid assertion" in {
+        StringContainsAssertion("the text string", "text").validated should be(valid)
+      }
+
+      "invalid" in {
+        StringContainsAssertion("the text string", "other").validated should be(invalid)
+      }
+
+    }
+
+    "RegexAssertion" must {
+      "valid assertion" in {
+        RegexAssertion("the text string sample 434", "\\d+".r).validated should be(valid)
+      }
+
+      "invalid" in {
+        RegexAssertion("the text string sample 434", "[A-Z]+".r).validated should be(invalid)
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Hello @agourlay 

I have done a modest contribution on your test api library with the support of regexp;

```
          Then assert body.path("name").regExpMatch(".*man".r)
```

let me know if you like it ^^

