### PR TITLE
First pass at formData support on HttpRequest

### DIFF
--- a/src/main/scala/com/github/agourlay/cornichon/http/HttpDsl.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/HttpDsl.scala
@@ -69,7 +69,7 @@ trait HttpDsl extends HttpRequestsDsl {
 
   def query_gql(url: String) = QueryGQL(url, Document(List.empty))
 
-  def open_sse(url: String, takeWithin: FiniteDuration) = HttpStreamedRequest(SSE, url, takeWithin, Seq.empty, Seq.empty)
+  def open_sse(url: String, takeWithin: FiniteDuration) = HttpStreamedRequest(SSE, url, takeWithin, Seq.empty, Seq.empty, Seq.empty)
 
   def status = StatusStepBuilder
 

--- a/src/main/scala/com/github/agourlay/cornichon/http/client/AkkaHttpClient.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/client/AkkaHttpClient.scala
@@ -84,13 +84,20 @@ class AkkaHttpClient(implicit system: ActorSystem, executionContext: ExecutionCo
     url: String,
     payload: Option[Json],
     params: Seq[(String, String)],
-    headers: Seq[(String, String)]
+    headers: Seq[(String, String)],
+    formData: Seq[(String, String)]
   ): Future[Either[CornichonError, CornichonHttpResponse]] = {
     val requestBuilder = httpMethodMapper(method)
     parseHttpHeaders(headers).fold(
       mh ⇒ Future.successful(Left(mh)),
       akkaHeaders ⇒ {
-        val request = requestBuilder(uriBuilder(url, params), payload).withHeaders(collection.immutable.Seq(akkaHeaders: _*))
+        val request = payload match {
+          case Some(json) ⇒ requestBuilder(uriBuilder(url, params), payload)
+            .withHeaders(collection.immutable.Seq(akkaHeaders: _*))
+          case _ ⇒ requestBuilder(uriBuilder(url, params), FormData(formData: _*))
+            .withHeaders(collection.immutable.Seq(akkaHeaders: _*))
+        }
+
         Http().singleRequest(request, sslContext).flatMap(toCornichonResponse)
       }
     )
@@ -101,7 +108,7 @@ class AkkaHttpClient(implicit system: ActorSystem, executionContext: ExecutionCo
 
   private def uriBuilder(url: String, params: Seq[(String, String)]): Uri = Uri(url).withQuery(Query(params: _*))
 
-  override def openStream(stream: HttpStream, url: String, params: Seq[(String, String)], headers: Seq[(String, String)], takeWithin: FiniteDuration) = {
+  override def openStream(stream: HttpStream, url: String, params: Seq[(String, String)], headers: Seq[(String, String)], formData: Seq[(String, String)], takeWithin: FiniteDuration) = {
     parseHttpHeaders(headers).fold(
       mh ⇒ Future.successful(Left(mh)),
       akkaHeaders ⇒ {

--- a/src/main/scala/com/github/agourlay/cornichon/http/client/HttpClient.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/client/HttpClient.scala
@@ -14,7 +14,8 @@ trait HttpClient {
     url: String,
     payload: Option[Json],
     params: Seq[(String, String)],
-    headers: Seq[(String, String)]
+    headers: Seq[(String, String)],
+    formData: Seq[(String, String)]
   ): Future[Either[CornichonError, CornichonHttpResponse]]
 
   def openStream(
@@ -22,6 +23,7 @@ trait HttpClient {
     url: String,
     params: Seq[(String, String)],
     headers: Seq[(String, String)],
+    formData: Seq[(String, String)],
     takeWithin: FiniteDuration
   ): Future[Either[CornichonError, CornichonHttpResponse]]
 

--- a/src/main/scala/com/github/agourlay/cornichon/http/server/MockServerRequestHandler.scala
+++ b/src/main/scala/com/github/agourlay/cornichon/http/server/MockServerRequestHandler.scala
@@ -103,7 +103,8 @@ case class MockServerRequestHandler(serverName: String)(implicit system: ActorSy
         url = akkaReq.uri.path.toString(),
         body = Some(decodedBody),
         params = akkaReq.uri.query().map(p ⇒ (p._1, p._2)),
-        headers = akkaReq.headers.map(h ⇒ (h.name(), h.value()))
+        headers = akkaReq.headers.map(h ⇒ (h.name(), h.value())),
+        formData = Seq.empty // TODO: need a real implementation, of course
       )
       (requestReceivedRepo ? RegisterRequest(req)).mapTo[RequestRegistered]
     }


### PR DESCRIPTION
This is a very basic implementation of the first option mentioned on #112 (addition of formData separate from payload). It still needs to be fleshed out and tested but the general shape is there for discussion.
