### PR TITLE
Don't import all cats instances in CornichonFeature

### DIFF
--- a/cornichon/src/it/scala/com.github.agourlay.cornichon.examples/DeckOfCard.scala
+++ b/cornichon/src/it/scala/com.github.agourlay.cornichon.examples/DeckOfCard.scala
@@ -1,5 +1,8 @@
 package com.github.agourlay.cornichon.examples
 
+import cats.instances.boolean._
+import cats.instances.int._
+import cats.instances.string._
 import com.github.agourlay.cornichon.CornichonFeature
 import com.github.agourlay.cornichon.steps.regular.assertStep.{AssertStep, GenericEqualityAssertion}
 

--- a/cornichon/src/it/scala/com.github.agourlay.cornichon.examples/OpenMovieDatabase.scala
+++ b/cornichon/src/it/scala/com.github.agourlay.cornichon.examples/OpenMovieDatabase.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.examples
 
+import cats.instances.string._
 import com.github.agourlay.cornichon.CornichonFeature
 
 class OpenMovieDatabase extends CornichonFeature {

--- a/cornichon/src/it/scala/com.github.agourlay.cornichon.examples/StarWars.scala
+++ b/cornichon/src/it/scala/com.github.agourlay.cornichon.examples/StarWars.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.examples
 
+import cats.instances.string._
 import com.github.agourlay.cornichon.CornichonFeature
 
 // see https://swapi.co/

--- a/cornichon/src/main/scala/com/github/agourlay/cornichon/dsl/AllInstances.scala
+++ b/cornichon/src/main/scala/com/github/agourlay/cornichon/dsl/AllInstances.scala
@@ -1,0 +1,23 @@
+package com.github.agourlay.cornichon.dsl
+
+import cats.instances._
+
+trait AllInstances
+  extends Instances
+    with StringInstances
+    with ListInstances
+    with OptionInstances
+    with SetInstances
+    with VectorInstances
+    with IntInstances
+    with CharInstances
+    with LongInstances
+    with ShortInstances
+    with FloatInstances
+    with DoubleInstances
+    with BooleanInstances
+    with BigIntInstances
+    with BigDecimalInstances
+    with UUIDInstances
+
+object AllInstances

--- a/cornichon/src/main/scala/com/github/agourlay/cornichon/dsl/Dsl.scala
+++ b/cornichon/src/main/scala/com/github/agourlay/cornichon/dsl/Dsl.scala
@@ -15,7 +15,7 @@ import scala.language.experimental.{ macros ⇒ `scalac, please just let me do i
 import scala.language.{ dynamics, higherKinds }
 import scala.concurrent.duration.FiniteDuration
 
-trait Dsl extends ProvidedInstances {
+trait Dsl {
   this: BaseFeature ⇒
 
   def Feature(name: String, ignored: Boolean = false) =

--- a/cornichon/src/main/scala/com/github/agourlay/cornichon/dsl/Instances.scala
+++ b/cornichon/src/main/scala/com/github/agourlay/cornichon/dsl/Instances.scala
@@ -6,22 +6,7 @@ import cats.syntax.show._
 
 import scala.collection.immutable.IndexedSeq
 
-// Importing Cats instances for Show and Eq to make it easier for potential non dev-users.
-trait ProvidedInstances extends StringInstances
-    with ListInstances
-    with OptionInstances
-    with SetInstances
-    with VectorInstances
-    with IntInstances
-    with CharInstances
-    with LongInstances
-    with ShortInstances
-    with FloatInstances
-    with DoubleInstances
-    with BooleanInstances
-    with BigIntInstances
-    with BigDecimalInstances
-    with UUIDInstances {
+trait Instances {
 
   implicit def showSeq[A: Show]: Show[Seq[A]] = Show.show { fa ⇒
     fa.toIterator.map(_.show).mkString("Seq(", ", ", ")")
@@ -40,4 +25,4 @@ trait ProvidedInstances extends StringInstances
   }
 }
 
-object ProvidedInstances extends ProvidedInstances
+object Instances extends Instances

--- a/cornichon/src/main/scala/com/github/agourlay/cornichon/dsl/SessionSteps.scala
+++ b/cornichon/src/main/scala/com/github/agourlay/cornichon/dsl/SessionSteps.scala
@@ -1,10 +1,13 @@
 package com.github.agourlay.cornichon.dsl
 
+import cats.instances.string._
+import cats.instances.boolean._
+import cats.instances.option._
 import com.github.agourlay.cornichon.core.SessionKey
 import com.github.agourlay.cornichon.json.JsonSteps.JsonStepBuilder
 import com.github.agourlay.cornichon.resolver.Resolver
 import com.github.agourlay.cornichon.steps.regular.assertStep.{ AssertStep, CustomMessageEqualityAssertion, GenericEqualityAssertion }
-import ProvidedInstances._
+import Instances._
 
 object SessionSteps {
 

--- a/cornichon/src/main/scala/com/github/agourlay/cornichon/http/HttpDsl.scala
+++ b/cornichon/src/main/scala/com/github/agourlay/cornichon/http/HttpDsl.scala
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets
 import java.util.Base64
 
 import cats.Show
+import cats.instances.string._
 import cats.syntax.show._
 import com.github.agourlay.cornichon.core._
 import com.github.agourlay.cornichon.dsl._
@@ -45,6 +46,7 @@ trait HttpDsl extends HttpRequestsDsl {
     )
 
   implicit def queryGqlToStep(queryGQL: QueryGQL): EffectStep = {
+    import Instances._
     import io.circe.generic.auto._
     import io.circe.syntax._
 

--- a/cornichon/src/main/scala/com/github/agourlay/cornichon/http/steps/HeadersSteps.scala
+++ b/cornichon/src/main/scala/com/github/agourlay/cornichon/http/steps/HeadersSteps.scala
@@ -1,11 +1,14 @@
 package com.github.agourlay.cornichon.http.steps
 
+import cats.instances.boolean._
+import cats.instances.list._
+import cats.instances.string._
 import com.github.agourlay.cornichon.core.SessionKey
 import com.github.agourlay.cornichon.http.HttpService
 import com.github.agourlay.cornichon.http.HttpService._
 import com.github.agourlay.cornichon.http.HttpService.SessionKeys._
 import com.github.agourlay.cornichon.steps.regular.assertStep._
-import com.github.agourlay.cornichon.dsl.ProvidedInstances._
+import com.github.agourlay.cornichon.dsl.Instances._
 import com.github.agourlay.cornichon.util.Printing._
 
 object HeadersSteps {

--- a/cornichon/src/main/scala/com/github/agourlay/cornichon/json/JsonDsl.scala
+++ b/cornichon/src/main/scala/com/github/agourlay/cornichon/json/JsonDsl.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.json
 
+import cats.instances.string._
 import cats.syntax.show._
 import com.github.agourlay.cornichon.dsl.Dsl
 import com.github.agourlay.cornichon.feature.BaseFeature

--- a/cornichon/src/main/scala/com/github/agourlay/cornichon/json/JsonSteps.scala
+++ b/cornichon/src/main/scala/com/github/agourlay/cornichon/json/JsonSteps.scala
@@ -1,6 +1,10 @@
 package com.github.agourlay.cornichon.json
 
 import cats.Show
+import cats.instances.boolean._
+import cats.instances.int._
+import cats.instances.string._
+import cats.instances.vector._
 import cats.syntax.show._
 import cats.syntax.either._
 import com.github.agourlay.cornichon.core.{ Session, SessionKey }
@@ -9,7 +13,7 @@ import com.github.agourlay.cornichon.resolver.{ Resolvable, Resolver }
 import com.github.agourlay.cornichon.json.CornichonJson._
 import com.github.agourlay.cornichon.matchers.MatcherService
 import com.github.agourlay.cornichon.steps.regular.assertStep._
-import com.github.agourlay.cornichon.dsl.ProvidedInstances._
+import com.github.agourlay.cornichon.dsl.Instances._
 import io.circe.{ Encoder, Json }
 
 import scala.util.matching.Regex

--- a/cornichon/src/main/scala/com/github/agourlay/cornichon/steps/regular/assertStep/CollectionAssertion.scala
+++ b/cornichon/src/main/scala/com/github/agourlay/cornichon/steps/regular/assertStep/CollectionAssertion.scala
@@ -5,7 +5,7 @@ import cats.data.Validated._
 import cats.data._
 import cats.syntax.show._
 import com.github.agourlay.cornichon.core.{ CornichonError, Done }
-import com.github.agourlay.cornichon.dsl.ProvidedInstances._
+import com.github.agourlay.cornichon.dsl.Instances._
 
 abstract class CollectionAssertion[A: Show] extends Assertion
 

--- a/cornichon/src/main/scala/com/github/agourlay/cornichon/steps/regular/assertStep/Diff.scala
+++ b/cornichon/src/main/scala/com/github/agourlay/cornichon/steps/regular/assertStep/Diff.scala
@@ -1,7 +1,8 @@
 package com.github.agourlay.cornichon.steps.regular.assertStep
 
 import cats.Show
-import com.github.agourlay.cornichon.dsl.ProvidedInstances._
+import cats.instances.set._
+import com.github.agourlay.cornichon.dsl.Instances._
 import cats.syntax.show._
 import io.circe.Json
 

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/core/EngineSpec.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/core/EngineSpec.scala
@@ -1,7 +1,9 @@
 package com.github.agourlay.cornichon.core
 
 import akka.actor.ActorSystem
-import com.github.agourlay.cornichon.dsl.ProvidedInstances._
+import cats.instances.boolean._
+import cats.instances.int._
+import com.github.agourlay.cornichon.dsl.Instances._
 import com.github.agourlay.cornichon.resolver.Resolver
 import com.github.agourlay.cornichon.steps.regular.assertStep.{ AssertStep, GenericEqualityAssertion }
 import org.scalatest.{ AsyncWordSpec, Matchers }

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/examples/MockServerExample.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/examples/MockServerExample.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.examples
 
+import cats.instances.string._
 import com.github.agourlay.cornichon.CornichonFeature
 import scala.concurrent.duration._
 

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/examples/math/MathScenario.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/examples/math/MathScenario.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.examples.math
 
+import cats.instances.int._
 import com.github.agourlay.cornichon.CornichonFeature
 import com.github.agourlay.cornichon.steps.regular.assertStep.{ AssertStep, GenericEqualityAssertion }
 

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/examples/math/MathSteps.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/examples/math/MathSteps.scala
@@ -1,5 +1,7 @@
 package com.github.agourlay.cornichon.examples.math
 
+import cats.instances.double._
+import cats.instances.int._
 import com.github.agourlay.cornichon.CornichonFeature
 import com.github.agourlay.cornichon.steps.regular.assertStep._
 import com.github.agourlay.cornichon.steps.regular.EffectStep

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/examples/superHeroes/SuperHeroesScenario.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/examples/superHeroes/SuperHeroesScenario.scala
@@ -4,6 +4,9 @@ import java.nio.charset.StandardCharsets
 import java.util.Base64
 
 import akka.http.scaladsl.Http.ServerBinding
+import cats.instances.boolean._
+import cats.instances.int._
+import cats.instances.string._
 import com.github.agourlay.cornichon.CornichonFeature
 import com.github.agourlay.cornichon.examples.superHeroes.server.HttpAPI
 import com.github.agourlay.cornichon.http.HttpService

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/json/CornichonJsonSpec.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/json/CornichonJsonSpec.scala
@@ -1,10 +1,16 @@
 package com.github.agourlay.cornichon.json
 
+import cats.instances.boolean._
+import cats.instances.double._
+import cats.instances.int._
+import cats.instances.long._
+import cats.instances.bigDecimal._
+import cats.instances.string._
 import io.circe.{ Json, JsonObject }
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{ Matchers, WordSpec }
 import cats.scalatest.{ EitherMatchers, EitherValues }
-import com.github.agourlay.cornichon.dsl.ProvidedInstances._
+import com.github.agourlay.cornichon.dsl.Instances._
 
 class CornichonJsonSpec extends WordSpec
     with Matchers

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/StepUtilSpec.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/StepUtilSpec.scala
@@ -2,12 +2,12 @@ package com.github.agourlay.cornichon.steps
 
 import akka.actor.ActorSystem
 import com.github.agourlay.cornichon.core.Engine
-import com.github.agourlay.cornichon.dsl.ProvidedInstances
+import com.github.agourlay.cornichon.dsl.Instances
 import com.github.agourlay.cornichon.resolver.Resolver
 
 import scala.concurrent.ExecutionContext
 
-trait StepUtilSpec extends ProvidedInstances {
+trait StepUtilSpec extends Instances {
 
   implicit val ec = ExecutionContext.global
   implicit val scheduler = ActorSystem("cornichon-actor-system").scheduler

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/regular/assertStep/AssertStepSpec.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/regular/assertStep/AssertStepSpec.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.steps.regular.assertStep
 
+import cats.instances.int._
 import cats.scalatest.EitherValues
 import com.github.agourlay.cornichon.core.{ Done, Scenario, Session }
 import com.github.agourlay.cornichon.steps.StepUtilSpec

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/ConcurrentlyStepSpec.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/ConcurrentlyStepSpec.scala
@@ -2,6 +2,7 @@ package com.github.agourlay.cornichon.steps.wrapped
 
 import java.util.concurrent.atomic.AtomicInteger
 
+import cats.instances.boolean._
 import com.github.agourlay.cornichon.core._
 import com.github.agourlay.cornichon.steps.StepUtilSpec
 import com.github.agourlay.cornichon.steps.regular.assertStep.{ AssertStep, GenericEqualityAssertion }

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/EventuallyStepSpec.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/EventuallyStepSpec.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.steps.wrapped
 
+import cats.instances.int._
 import com.github.agourlay.cornichon.core._
 import com.github.agourlay.cornichon.steps.StepUtilSpec
 import com.github.agourlay.cornichon.steps.regular.assertStep.{ AssertStep, GenericEqualityAssertion }

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/RepeatDuringStepSpec.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/RepeatDuringStepSpec.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.steps.wrapped
 
+import cats.instances.boolean._
 import com.github.agourlay.cornichon.core._
 import com.github.agourlay.cornichon.steps.StepUtilSpec
 import com.github.agourlay.cornichon.steps.regular.assertStep.{ AssertStep, GenericEqualityAssertion }

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/RepeatStepSpec.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/RepeatStepSpec.scala
@@ -1,5 +1,7 @@
 package com.github.agourlay.cornichon.steps.wrapped
 
+import cats.instances.boolean._
+import cats.instances.string._
 import com.github.agourlay.cornichon.core._
 import com.github.agourlay.cornichon.steps.StepUtilSpec
 import com.github.agourlay.cornichon.steps.regular.assertStep.{ AssertStep, GenericEqualityAssertion }

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/RepeatWithStepSpec.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/RepeatWithStepSpec.scala
@@ -1,5 +1,7 @@
 package com.github.agourlay.cornichon.steps.wrapped
 
+import cats.instances.boolean._
+import cats.instances.string._
 import com.github.agourlay.cornichon.core._
 import com.github.agourlay.cornichon.steps.StepUtilSpec
 import com.github.agourlay.cornichon.steps.regular.assertStep.{ AssertStep, GenericEqualityAssertion }

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/RetryMaxStepSpec.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/RetryMaxStepSpec.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.steps.wrapped
 
+import cats.instances.boolean._
 import com.github.agourlay.cornichon.core._
 import com.github.agourlay.cornichon.steps.StepUtilSpec
 import com.github.agourlay.cornichon.steps.regular.assertStep.{ AssertStep, GenericEqualityAssertion }

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/WithDataInputStepSpec.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/WithDataInputStepSpec.scala
@@ -1,5 +1,7 @@
 package com.github.agourlay.cornichon.steps.wrapped
 
+import cats.instances.boolean._
+import cats.instances.int._
 import com.github.agourlay.cornichon.core._
 import com.github.agourlay.cornichon.steps.StepUtilSpec
 import com.github.agourlay.cornichon.steps.regular.assertStep.{ AssertStep, GenericEqualityAssertion }

--- a/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/WithinStepSpec.scala
+++ b/cornichon/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/WithinStepSpec.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.steps.wrapped
 
+import cats.instances.boolean._
 import com.github.agourlay.cornichon.core._
 import com.github.agourlay.cornichon.steps.StepUtilSpec
 import com.github.agourlay.cornichon.steps.regular.assertStep.{ AssertStep, GenericEqualityAssertion }


### PR DESCRIPTION
As there is a bunch of implicit in `CornichonFeature`'s scope, the
implicit resolution makes compilation slow and IDE user experience
really painfull.

To overcome this problem, this commit proposes to let the user the
choice of importing all cats instances by mixin `AllInstances` trait in
`CornichonFeature` or picking only the instances he needs if he is a
more advance user.