### PR TITLE
Add implicit conversion QueryGQL -> HttpRequest[String] for better gr…

### DIFF
--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/HttpDsl.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/HttpDsl.scala
@@ -25,7 +25,6 @@ import com.github.agourlay.cornichon.http.steps.HttpListenSteps._
 import com.github.agourlay.cornichon.util.Printing._
 import io.circe.Encoder
 import sangria.ast.Document
-import sangria.renderer.QueryRenderer
 
 import scala.concurrent.duration._
 
@@ -46,7 +45,7 @@ trait HttpDsl extends HttpRequestsDsl {
 
   implicit def queryGqlToStep(queryGQL: QueryGQL): EffectStep = {
     // Used only for display - problem being that the query is a String and looks ugly inside the full JSON object.
-    val prettyPayload = queryGQL.query.source.getOrElse(QueryRenderer.render(queryGQL.query, QueryRenderer.Pretty))
+    val prettyPayload = queryGQL.querySource
 
     val prettyVar = queryGQL.variables.fold("") { variables ⇒
       " and with variables " + variables.show
@@ -56,7 +55,7 @@ trait HttpDsl extends HttpRequestsDsl {
 
     EffectStep(
       title = s"query GraphQL endpoint ${queryGQL.url} with query $prettyPayload$prettyVar$prettyOp",
-      effect = http.requestEffect(post(queryGQL.url).withBody(queryGQL.payload))
+      effect = http.requestEffect(queryGQL)
     )
   }
 

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/HttpRequest.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/HttpRequest.scala
@@ -130,11 +130,12 @@ case class QueryGQL(url: String, query: Document, operationName: Option[String] 
     copy(variables = variables.fold(Some(vars))(v ⇒ Some(v ++ vars)))
   }
 
+  lazy val querySource = query.source.getOrElse(QueryRenderer.render(query, QueryRenderer.Pretty))
+
   lazy val payload: String = {
     import io.circe.generic.auto._
     import io.circe.syntax._
 
-    val querySource = query.source.getOrElse(QueryRenderer.render(query, QueryRenderer.Compact))
     GqlPayload(querySource, operationName, variables).asJson.show
   }
 


### PR DESCRIPTION
@agourlay I'm trying to test my university project and the current implicit conversion from 
QueryGQL to EffectStep does not allow me to conveniently 
* Assert expected status
* Extract response values
* Set and show titles for steps when executing tests

with this slight change i can define steps with the same api like `http.requestEffect`

example:
```scala
  def register_a_user(handle: String, name: String) = EffectStep(
    title = s"register a user with twitter handle '$handle'",
    effect = http.requestEffect(
      request = query_gql("/graphql")
        .withVariables(
          "handle" → handle,
          "name" → name)
        .withQuery(
          graphql"""
            mutation RegisterUser($$handle: String!, $$name: String!) {
              registerUser(handle: $$handle, name: $$name) {
                id
              }
            }
          """),
      extractor = PathExtractor("data.registerUser", "user"),
      expectedStatus = Some(200)
    ),
    show = true)
```

I didn't add a test jet since I didn't find a proper place but I published locally and teste it in my project. If you think this is useful, let me know where and I will add a test.

Greetings, Peter