### PR TITLE
Introduce new experimental module without dependency to Scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ lazy val noPublishSettings = Seq(
 lazy val cornichon =
   project
     .in(file("."))
-    .aggregate(core, scalatest, docs, benchmarks)
+    .aggregate(core, scalatest, docs, benchmarks, experimental)
     .settings(commonSettings)
     .settings(noPublishSettings)
     .settings(
@@ -116,6 +116,21 @@ lazy val scalatest =
       libraryDependencies ++= Seq(
         library.scalatest,
         library.akkHttpCirce % Test
+      )
+    )
+
+lazy val experimental =
+  project
+    .in(file("./cornichon-experimental"))
+    .dependsOn(core)
+    .enablePlugins(SbtScalariform)
+    .settings(commonSettings)
+    .settings(scalariformSettings)
+    .settings(
+      name := "cornichon-experimental",
+      testFrameworks += new TestFramework("com.github.agourlay.cornichon.sbtinterface.CornichonFramework"),
+      libraryDependencies ++= Seq(
+        library.sbtTest
       )
     )
 
@@ -196,6 +211,7 @@ lazy val library =
       val catsScalaTest = "2.2.0"
       val ficus         = "1.4.0"
       val monix         = "2.3.0"
+      val sbtTest       = "1.0"
     }
     val akkaActor     = "com.typesafe.akka"   %% "akka-actor"      % Version.akkaActor
     val akkaStream    = "com.typesafe.akka"   %% "akka-stream"     % Version.akkaActor
@@ -218,4 +234,5 @@ lazy val library =
     val scalacheck    = "org.scalacheck"      %% "scalacheck"      % Version.scalaCheck
     val catsScalatest = "com.ironcorelabs"    %% "cats-scalatest"  % Version.catsScalaTest
     val monixExec     = "io.monix"            %% "monix-execution" % Version.monix
+    val sbtTest       = "org.scala-sbt"       %  "test-interface"  % Version.sbtTest
   }

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Engine.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Engine.scala
@@ -16,8 +16,8 @@ import scala.util.control.NonFatal
 
 class Engine(stepPreparers: List[StepPreparer])(implicit scheduler: Scheduler) {
 
-  def runScenario(session: Session, finallySteps: List[Step] = Nil)(scenario: Scenario): Future[ScenarioReport] =
-    if (scenario.ignored)
+  def runScenario(session: Session, finallySteps: List[Step] = Nil, featureIgnored: Boolean = false)(scenario: Scenario): Future[ScenarioReport] =
+    if (featureIgnored || scenario.ignored)
       Future.successful(IgnoreScenarioReport(scenario.name, session, Vector.empty))
     else {
       val initMargin = 1

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/LogInstruction.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/LogInstruction.scala
@@ -42,6 +42,10 @@ case class SuccessLogInstruction(message: String, marginNb: Int, duration: Optio
   val colorized = fansi.Color.Green(completeMessage).render
 }
 
+case class WarningLogInstruction(message: String, marginNb: Int, duration: Option[Duration] = None) extends LogInstruction {
+  val colorized = fansi.Color.Yellow(completeMessage).render
+}
+
 case class FailureLogInstruction(message: String, marginNb: Int, duration: Option[Duration] = None) extends LogInstruction {
   val colorized = fansi.Color.Red(completeMessage).render
 }

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/ScenarioReport.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/ScenarioReport.scala
@@ -20,10 +20,13 @@ object ScenarioReport {
 
 case class SuccessScenarioReport(scenarioName: String, session: Session, logs: Vector[LogInstruction]) extends ScenarioReport {
   val isSuccess = true
+
+  // In case of success, logs are only shown if the scenario contains DebugLogInstruction
+  val shouldShowLogs = logs.collect { case d: DebugLogInstruction ⇒ d }.nonEmpty
 }
 
 case class IgnoreScenarioReport(scenarioName: String, session: Session, logs: Vector[LogInstruction]) extends ScenarioReport {
-  val isSuccess = true
+  val isSuccess = false
 }
 
 case class FailureScenarioReport(scenarioName: String, failedSteps: NonEmptyList[FailedStep], session: Session, logs: Vector[LogInstruction]) extends ScenarioReport {

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/ScenarioReport.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/ScenarioReport.scala
@@ -5,6 +5,7 @@ import cats.kernel.Semigroup
 
 sealed trait ScenarioReport {
   def isSuccess: Boolean
+  def scenarioName: String
   def session: Session
   def logs: Vector[LogInstruction]
 }
@@ -18,6 +19,10 @@ object ScenarioReport {
 }
 
 case class SuccessScenarioReport(scenarioName: String, session: Session, logs: Vector[LogInstruction]) extends ScenarioReport {
+  val isSuccess = true
+}
+
+case class IgnoreScenarioReport(scenarioName: String, session: Session, logs: Vector[LogInstruction]) extends ScenarioReport {
   val isSuccess = true
 }
 

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/feature/BaseFeature.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/feature/BaseFeature.scala
@@ -47,7 +47,7 @@ trait BaseFeature extends HttpDsl with JsonDsl with Dsl {
 
   protected def unregisterFeature() = releaseGlobalRuntime()
 
-  protected def runScenario(s: Scenario) = {
+  def runScenario(s: Scenario) = {
     println(s"Starting scenario '${s.name}'")
     engine.runScenario(Session.newEmpty, afterEachScenario.toList) {
       s.copy(steps = beforeEachScenario.toList ++ s.steps)
@@ -81,7 +81,7 @@ object BaseFeature {
   implicit private lazy val mat = ActorMaterializer()
 
   private lazy val executorService = Executors.newScheduledThreadPool(
-    2,
+    Runtime.getRuntime.availableProcessors() + 1,
     new ThreadFactory {
       val count = new AtomicInteger(0)
       override def newThread(r: Runnable) = {

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/server/HttpMockServerResource.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/server/HttpMockServerResource.scala
@@ -3,7 +3,6 @@ package com.github.agourlay.cornichon.http.server
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 
-import com.github.agourlay.cornichon.feature.BaseFeature
 import com.github.agourlay.cornichon.core.Session
 import com.github.agourlay.cornichon.dsl.{ BlockScopedResource, ResourceHandle }
 import com.github.agourlay.cornichon.http.server.HttpMockServerResource.SessionKeys._
@@ -23,7 +22,6 @@ case class HttpMockServerResource(
   val closingTitle: String = s"Shutting down HTTP mock server '$label'"
 
   def startResource() = {
-    BaseFeature.reserveGlobalRuntime()
     val mockRequestHandler = MockServerRequestHandler(label)
     val akkaServer = new AkkaHttpServer(interface, portRange, mockRequestHandler.requestHandler)
     akkaServer.startServer().map { serverCloseHandler ⇒
@@ -34,7 +32,6 @@ case class HttpMockServerResource(
 
         def stopResource() = serverCloseHandler._2.stopResource().map { _ ⇒
           mockRequestHandler.shutdown()
-          BaseFeature.releaseGlobalRuntime()
         }
       }
     }

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/server/MockServerRequestHandler.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/server/MockServerRequestHandler.scala
@@ -3,7 +3,7 @@ package com.github.agourlay.cornichon.http.server
 import java.util.UUID
 
 import akka.pattern._
-import akka.actor.ActorSystem
+import akka.actor.{ ActorSystem, PoisonPill }
 import akka.http.scaladsl.client.RequestBuilding._
 import akka.http.scaladsl.coding.Gzip
 import akka.http.scaladsl.model.HttpMethods._
@@ -109,5 +109,5 @@ case class MockServerRequestHandler(serverName: String)(implicit system: ActorSy
     }
   }
 
-  def shutdown() = requestReceivedRepo ! ClearRegisteredRequest
+  def shutdown() = requestReceivedRepo ! PoisonPill
 }

--- a/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/CornichonFeature.scala
+++ b/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/CornichonFeature.scala
@@ -1,0 +1,5 @@
+package com.github.agourlay.cornichon
+
+import com.github.agourlay.cornichon.feature.BaseFeature
+
+trait CornichonFeature extends BaseFeature

--- a/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/CornichonFingerprint.scala
+++ b/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/CornichonFingerprint.scala
@@ -2,7 +2,7 @@ package com.github.agourlay.cornichon.sbtinterface
 
 import sbt.testing.SubclassFingerprint
 
-private[cornichon] class CornichonFingerprint extends SubclassFingerprint {
+object CornichonFingerprint extends SubclassFingerprint {
   override def isModule: Boolean = false
 
   override def superclassName(): String = "com.github.agourlay.cornichon.CornichonFeature"

--- a/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/CornichonFingerprint.scala
+++ b/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/CornichonFingerprint.scala
@@ -1,0 +1,11 @@
+package com.github.agourlay.cornichon.sbtinterface
+
+import sbt.testing.SubclassFingerprint
+
+private[cornichon] class CornichonFingerprint extends SubclassFingerprint {
+  override def isModule: Boolean = false
+
+  override def superclassName(): String = "com.github.agourlay.cornichon.CornichonFeature"
+
+  def requireNoArgConstructor(): Boolean = false
+}

--- a/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/CornichonFramework.scala
+++ b/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/CornichonFramework.scala
@@ -2,9 +2,9 @@ package com.github.agourlay.cornichon.sbtinterface
 
 import sbt.testing._
 
-private[cornichon] class CornichonFramework extends Framework {
+class CornichonFramework extends Framework {
 
-  override def fingerprints(): Array[Fingerprint] = Array(new CornichonFingerprint)
+  override def fingerprints(): Array[Fingerprint] = Array(CornichonFingerprint)
 
   def runner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader): Runner =
     new CornichonRunner(args, remoteArgs, testClassLoader)

--- a/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/CornichonFramework.scala
+++ b/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/CornichonFramework.scala
@@ -1,0 +1,14 @@
+package com.github.agourlay.cornichon.sbtinterface
+
+import sbt.testing._
+
+private[cornichon] class CornichonFramework extends Framework {
+
+  override def fingerprints(): Array[Fingerprint] = Array(new CornichonFingerprint)
+
+  def runner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader): Runner =
+    new CornichonRunner(args, remoteArgs, testClassLoader)
+
+  override def name(): String = "cornichon"
+
+}

--- a/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/CornichonRunner.scala
+++ b/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/CornichonRunner.scala
@@ -1,6 +1,12 @@
 package com.github.agourlay.cornichon.sbtinterface
 
+import java.util.concurrent.atomic.AtomicBoolean
+
+import com.github.agourlay.cornichon.feature.BaseFeature
 import sbt.testing._
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 private[cornichon] class CornichonRunner(
     val args: Array[String],
@@ -8,13 +14,18 @@ private[cornichon] class CornichonRunner(
     testClassLoader: ClassLoader
 ) extends Runner {
 
+  val gotTasks = new AtomicBoolean(false)
+
   override def tasks(taskDefs: Array[TaskDef]) = {
-    //TODO call resource setup
-    taskDefs.map(new SbtCornichonTask(_, testClassLoader))
+    gotTasks.set(true)
+    taskDefs.map(new SbtCornichonTask(_))
   }
 
+  //For some reason CornichonRunner is instantiated twice thus this is called twice?!
+  //TODO build nice summary report instead of 'Done!"
   override def done(): String = {
-    //TODO call resource teardown
+    if (gotTasks.get)
+      Await.result(BaseFeature.shutDownGlobalResources(), Duration.Inf)
     "Done!"
   }
 

--- a/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/CornichonRunner.scala
+++ b/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/CornichonRunner.scala
@@ -1,0 +1,21 @@
+package com.github.agourlay.cornichon.sbtinterface
+
+import sbt.testing._
+
+private[cornichon] class CornichonRunner(
+    val args: Array[String],
+    val remoteArgs: Array[String],
+    testClassLoader: ClassLoader
+) extends Runner {
+
+  override def tasks(taskDefs: Array[TaskDef]) = {
+    //TODO call resource setup
+    taskDefs.map(new SbtCornichonTask(_, testClassLoader))
+  }
+
+  override def done(): String = {
+    //TODO call resource teardown
+    "Done!"
+  }
+
+}

--- a/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/CornichonRunner.scala
+++ b/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/CornichonRunner.scala
@@ -8,25 +8,20 @@ import sbt.testing._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-private[cornichon] class CornichonRunner(
-    val args: Array[String],
-    val remoteArgs: Array[String],
-    testClassLoader: ClassLoader
-) extends Runner {
+class CornichonRunner(val args: Array[String], val remoteArgs: Array[String], testClassLoader: ClassLoader) extends Runner {
 
-  val gotTasks = new AtomicBoolean(false)
+  private val gotTasks = new AtomicBoolean(false)
 
   override def tasks(taskDefs: Array[TaskDef]) = {
+    BaseFeature.disableAutomaticResourceCleanup()
     gotTasks.set(true)
     taskDefs.map(new SbtCornichonTask(_))
   }
 
-  //For some reason CornichonRunner is instantiated twice thus this is called twice?!
-  //TODO build nice summary report instead of 'Done!"
   override def done(): String = {
-    if (gotTasks.get)
-      Await.result(BaseFeature.shutDownGlobalResources(), Duration.Inf)
-    "Done!"
+    //For some reason CornichonRunner is instantiated twice thus this is called twice?!
+    if (gotTasks.get) Await.result(BaseFeature.shutDownGlobalResources(), Duration.Inf)
+    ""
   }
 
 }

--- a/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/SbtCornichonReporter.scala
+++ b/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/SbtCornichonReporter.scala
@@ -1,0 +1,5 @@
+package com.github.agourlay.cornichon.sbtinterface
+
+class SbtCornichonReporter {
+
+}

--- a/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/SbtCornichonReporter.scala
+++ b/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/SbtCornichonReporter.scala
@@ -1,5 +1,0 @@
-package com.github.agourlay.cornichon.sbtinterface
-
-class SbtCornichonReporter {
-
-}

--- a/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/SbtCornichonTask.scala
+++ b/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/SbtCornichonTask.scala
@@ -1,0 +1,76 @@
+package com.github.agourlay.cornichon.sbtinterface
+
+import com.github.agourlay.cornichon.core._
+import com.github.agourlay.cornichon.feature.BaseFeature
+import sbt.testing._
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, Future, Promise }
+
+class SbtCornichonTask(task: TaskDef, cl: ClassLoader) extends Task {
+
+  override def tags(): Array[String] = Array.empty
+  def taskDef(): TaskDef = task
+
+  override def execute(eventHandler: EventHandler, loggers: Array[Logger]): Array[Task] = {
+    val p = Promise[Unit]()
+    execute(eventHandler, loggers, _ ⇒ p.success(()))
+    Await.result(p.future, Duration.Inf)
+    Array.empty
+  }
+
+  def execute(eventHandler: EventHandler, loggers: Array[Logger],
+    continuation: (Array[Task]) ⇒ Unit): Unit = {
+
+    implicit val ec = BaseFeature.globalRuntime._4
+
+    val c = Class.forName(task.fullyQualifiedName())
+    val cons = c.getConstructor()
+    val baseFeature = cons.newInstance().asInstanceOf[BaseFeature]
+
+    val featureName = baseFeature.feature.name
+    println(SuccessLogInstruction(s"$featureName:", 0).colorized)
+
+    val featRes = baseFeature.feature.scenarios.map { s ⇒
+      val startTS = System.currentTimeMillis()
+      BaseFeature.reserveGlobalRuntime()
+      baseFeature.runScenario(s).map { r ⇒
+        //Generate result event
+        val endTS = System.currentTimeMillis()
+        eventHandler.handle(eventBuilder(r, endTS - startTS))
+        BaseFeature.releaseGlobalRuntime()
+        r
+      }
+    }
+
+    Future.sequence(featRes)
+      .map(results ⇒ results.foreach(printResultLogs))
+      .onComplete(_ ⇒ continuation(Array.empty))
+  }
+
+  def printResultLogs(sr: ScenarioReport) = sr match {
+    case s: SuccessScenarioReport ⇒
+      // In case of success, logs are only shown if the scenario contains DebugLogInstruction
+      if (s.logs.collect { case d: DebugLogInstruction ⇒ d }.nonEmpty)
+        LogInstruction.printLogs(s.logs)
+      else {
+        val msg = s"- should ${s.scenarioName} "
+        println(SuccessLogInstruction(msg, 0).colorized)
+      }
+    case f: FailureScenarioReport ⇒
+      LogInstruction.printLogs(f.logs)
+  }
+
+  def eventBuilder(sr: ScenarioReport, durationInMillis: Long) = new Event {
+    val status = sr match {
+      case _: SuccessScenarioReport ⇒ Status.Success
+      case _: FailureScenarioReport ⇒ Status.Failure
+    }
+    val throwable = new OptionalThrowable()
+    val fullyQualifiedName = task.fullyQualifiedName()
+    val selector = task.selectors().head
+    val fingerprint = task.fingerprint()
+    val duration = durationInMillis
+  }
+
+}

--- a/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/SbtCornichonTask.scala
+++ b/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/sbtinterface/SbtCornichonTask.scala
@@ -7,7 +7,7 @@ import sbt.testing._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, Future, Promise }
 
-class SbtCornichonTask(task: TaskDef, cl: ClassLoader) extends Task {
+class SbtCornichonTask(task: TaskDef) extends Task {
 
   override def tags(): Array[String] = Array.empty
   def taskDef(): TaskDef = task
@@ -59,12 +59,16 @@ class SbtCornichonTask(task: TaskDef, cl: ClassLoader) extends Task {
       }
     case f: FailureScenarioReport ⇒
       LogInstruction.printLogs(f.logs)
+    case i: IgnoreScenarioReport ⇒
+      val msg = s"- **ignored** ${i.scenarioName} "
+      println(WarningLogInstruction(msg, 0).colorized)
   }
 
   def eventBuilder(sr: ScenarioReport, durationInMillis: Long) = new Event {
     val status = sr match {
       case _: SuccessScenarioReport ⇒ Status.Success
       case _: FailureScenarioReport ⇒ Status.Failure
+      case _: IgnoreScenarioReport  ⇒ Status.Ignored
     }
     val throwable = new OptionalThrowable()
     val fullyQualifiedName = task.fullyQualifiedName()

--- a/cornichon-experimental/src/test/scala/com/github/agourlay/cornichon/examples/DummyExamplesOne.scala
+++ b/cornichon-experimental/src/test/scala/com/github/agourlay/cornichon/examples/DummyExamplesOne.scala
@@ -1,0 +1,35 @@
+package com.github.agourlay.cornichon.examples
+
+import com.github.agourlay.cornichon.CornichonFeature
+
+class DummyExamplesOne extends DummyFeatureToTestInheritance {
+
+  def feature = Feature("Dummy one feature") {
+
+    Scenario("session access") {
+
+      When I save("arg1" → "cornichon")
+
+      Then assert session_value("arg1").is("cornichon")
+
+    }
+
+    Scenario("printing step") {
+
+      And I print_step("hello world!")
+
+    }
+  }
+}
+
+trait DummyFeatureToTestInheritance extends CornichonFeature {
+
+  beforeEachScenario(
+    print_step("before each scenario dummy one")
+  )
+
+  afterEachScenario(
+    print_step("before each scenario dummy one")
+  )
+
+}

--- a/cornichon-experimental/src/test/scala/com/github/agourlay/cornichon/examples/DummyExamplesOne.scala
+++ b/cornichon-experimental/src/test/scala/com/github/agourlay/cornichon/examples/DummyExamplesOne.scala
@@ -29,7 +29,7 @@ trait DummyFeatureToTestInheritance extends CornichonFeature {
   )
 
   afterEachScenario(
-    print_step("before each scenario dummy one")
+    print_step("after each scenario dummy one")
   )
 
 }

--- a/cornichon-experimental/src/test/scala/com/github/agourlay/cornichon/examples/DummyExamplesThree.scala
+++ b/cornichon-experimental/src/test/scala/com/github/agourlay/cornichon/examples/DummyExamplesThree.scala
@@ -1,0 +1,33 @@
+package com.github.agourlay.cornichon.examples
+
+import com.github.agourlay.cornichon.CornichonFeature
+import scala.concurrent.duration._
+
+class DummyExamplesThree extends CornichonFeature {
+
+  def feature = Feature("Dummy three feature") {
+
+    Scenario("session access") {
+
+      When I save("arg1" → "cornichon")
+
+      Then assert session_value("arg1").is("cornichon")
+
+    }
+
+    Scenario("waiting step") {
+
+      And I wait(1.second)
+
+    }
+  }
+
+  beforeEachScenario(
+    print_step("before each scenario dummy three")
+  )
+
+  afterEachScenario(
+    print_step("before each scenario dummy three")
+  )
+
+}

--- a/cornichon-experimental/src/test/scala/com/github/agourlay/cornichon/examples/DummyExamplesThree.scala
+++ b/cornichon-experimental/src/test/scala/com/github/agourlay/cornichon/examples/DummyExamplesThree.scala
@@ -27,7 +27,7 @@ class DummyExamplesThree extends CornichonFeature {
   )
 
   afterEachScenario(
-    print_step("before each scenario dummy three")
+    print_step("after each scenario dummy three")
   )
 
 }

--- a/cornichon-experimental/src/test/scala/com/github/agourlay/cornichon/examples/DummyExamplesTwo.scala
+++ b/cornichon-experimental/src/test/scala/com/github/agourlay/cornichon/examples/DummyExamplesTwo.scala
@@ -15,7 +15,7 @@ class DummyExamplesTwo extends CornichonFeature {
 
     }
 
-    Scenario("waiting step") {
+    Scenario("waiting step", ignored = true) {
 
       And I wait(1.second)
 
@@ -27,7 +27,7 @@ class DummyExamplesTwo extends CornichonFeature {
   )
 
   afterEachScenario(
-    print_step("before each scenario dummy two")
+    print_step("after each scenario dummy two")
   )
 
 }

--- a/cornichon-experimental/src/test/scala/com/github/agourlay/cornichon/examples/DummyExamplesTwo.scala
+++ b/cornichon-experimental/src/test/scala/com/github/agourlay/cornichon/examples/DummyExamplesTwo.scala
@@ -1,0 +1,33 @@
+package com.github.agourlay.cornichon.examples
+
+import com.github.agourlay.cornichon.CornichonFeature
+import scala.concurrent.duration._
+
+class DummyExamplesTwo extends CornichonFeature {
+
+  def feature = Feature("Dummy two feature") {
+
+    Scenario("session access") {
+
+      When I save("arg1" → "cornichon")
+
+      Then assert session_value("arg1").is("cornichon")
+
+    }
+
+    Scenario("waiting step") {
+
+      And I wait(1.second)
+
+    }
+  }
+
+  beforeEachScenario(
+    print_step("before each scenario dummy two")
+  )
+
+  afterEachScenario(
+    print_step("before each scenario dummy two")
+  )
+
+}

--- a/cornichon-scalatest/src/main/scala/com/github/agourlay/cornichon/scalatest/ScalatestFeature.scala
+++ b/cornichon-scalatest/src/main/scala/com/github/agourlay/cornichon/scalatest/ScalatestFeature.scala
@@ -50,8 +50,7 @@ trait ScalatestFeature extends AsyncWordSpecLike with BeforeAndAfterAll with Par
             s.name in {
               runScenario(s).map {
                 case s: SuccessScenarioReport ⇒
-                  // In case of success, logs are only shown if the scenario contains DebugLogInstruction
-                  if (s.logs.collect { case d: DebugLogInstruction ⇒ d }.nonEmpty) printLogs(s.logs)
+                  if (s.shouldShowLogs) printLogs(s.logs)
                   assert(true)
                 case f: FailureScenarioReport ⇒
                   printLogs(f.logs)

--- a/cornichon-scalatest/src/main/scala/com/github/agourlay/cornichon/scalatest/ScalatestFeature.scala
+++ b/cornichon-scalatest/src/main/scala/com/github/agourlay/cornichon/scalatest/ScalatestFeature.scala
@@ -1,7 +1,7 @@
 package com.github.agourlay.cornichon.scalatest
 
 import com.github.agourlay.cornichon.core.LogInstruction._
-import com.github.agourlay.cornichon.core.{ CornichonError, DebugLogInstruction, FailureScenarioReport, SuccessScenarioReport }
+import com.github.agourlay.cornichon.core._
 import com.github.agourlay.cornichon.feature.BaseFeature
 import org.scalatest._
 
@@ -12,13 +12,13 @@ trait ScalatestFeature extends AsyncWordSpecLike with BeforeAndAfterAll with Par
   this: BaseFeature ⇒
 
   override def beforeAll() = {
-    registerFeature()
+    BaseFeature.reserveGlobalRuntime()
     beforeFeature.foreach(f ⇒ f())
   }
 
   override def afterAll() = {
     afterFeature.foreach(f ⇒ f())
-    unregisterFeature()
+    BaseFeature.releaseGlobalRuntime()
   }
 
   override def run(testName: Option[String], args: Args) =
@@ -60,6 +60,8 @@ trait ScalatestFeature extends AsyncWordSpecLike with BeforeAndAfterAll with Par
                         |${fansi.Color.Red("replay only this scenario with the command:").overlay(attrs = fansi.Underlined.On).render}
                         |${scalaTestReplayCmd(feat.name, s.name)}""".stripMargin
                   )
+                case i: IgnoreScenarioReport ⇒
+                  throw new RuntimeException(s"Scalatest filters ignored scenario upstream, this should never happen\n$i")
               }
             }
         }


### PR DESCRIPTION
This cleans up the DSL scope from all the Scalatest leaked members
http://agourlay.github.io/cornichon/api/com/github/agourlay/cornichon/scalatest/ScalatestFeature.html

Removing those implicits should improve the compilation time a bit.

To use it one needs to add in the build.sbt
"com.github.agourlay" %% "cornichon-experimental" % "0.12.1-SNAPSHOT"
and
testFrameworks += new TestFramework("com.github.agourlay.cornichon.sbtinterface.CornichonFramework")

sbt testOnly *xxxx works out of the box to run a specific Feature.

There a couple a things missing to make it really usable:
- support testOnly at the scenario level like it is done with Scalatest
- ship a Teamcity reporter so that results are picked by the CI server
- maybe having a dedicated main runner like scalatest to run without sbt?

ref : https://github.com/agourlay/cornichon/issues/68