### PR TITLE
Add ResourceStep to allow cleaning up acquired resources

### DIFF
--- a/cornichon-benchmarks/src/main/scala/engine/EngineBench.scala
+++ b/cornichon-benchmarks/src/main/scala/engine/EngineBench.scala
@@ -3,6 +3,7 @@ package engine
 import java.util.concurrent.{ ExecutorService, Executors }
 
 import cats.instances.int._
+import cats.syntax.either._
 import com.github.agourlay.cornichon.core.{ Engine, Scenario, Session }
 import com.github.agourlay.cornichon.resolver.PlaceholderResolver
 import com.github.agourlay.cornichon.steps.regular.EffectStep

--- a/cornichon-benchmarks/src/main/scala/engine/EngineBench.scala
+++ b/cornichon-benchmarks/src/main/scala/engine/EngineBench.scala
@@ -3,7 +3,6 @@ package engine
 import java.util.concurrent.{ ExecutorService, Executors }
 
 import cats.instances.int._
-import cats.syntax.either._
 import com.github.agourlay.cornichon.core.{ Engine, Scenario, Session }
 import com.github.agourlay.cornichon.resolver.PlaceholderResolver
 import com.github.agourlay.cornichon.steps.regular.EffectStep

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/RunState.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/RunState.scala
@@ -6,7 +6,13 @@ import cats.instances.vector._
 import cats.kernel.Monoid
 import cats.syntax.monoid._
 
-case class RunState(remainingSteps: List[Step], session: Session, logs: Vector[LogInstruction], depth: Int) {
+case class RunState(
+    remainingSteps: List[Step],
+    session: Session,
+    logs: Vector[LogInstruction],
+    depth: Int,
+    cleanupSteps: List[Step]
+) {
 
   lazy val goDeeper = copy(depth = depth + 1)
 
@@ -36,7 +42,7 @@ case class RunState(remainingSteps: List[Step], session: Session, logs: Vector[L
 object RunState {
 
   implicit val monoidRunState = new Monoid[RunState] {
-    def empty: RunState = RunState(Nil, Session.newEmpty, Vector.empty, 1)
+    def empty: RunState = RunState(Nil, Session.newEmpty, Vector.empty, 1, Nil)
     def combine(x: RunState, y: RunState): RunState = x.copy(
       remainingSteps = x.remainingSteps.combine(y.remainingSteps),
       session = x.session.combine(y.session),

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/steps/regular/ResourceStep.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/steps/regular/ResourceStep.scala
@@ -1,0 +1,22 @@
+package com.github.agourlay.cornichon.steps.regular
+
+import com.github.agourlay.cornichon.core._
+
+import scala.concurrent.duration.Duration
+
+case class ResourceStep[R](title: String, acquire: Step, release: Step) extends SimpleWrapperStep {
+  def nestedToRun: List[Step] = List(acquire)
+
+  def onNestedError(
+    failedStep: FailedStep,
+    resultRunState: RunState,
+    initialRunState: RunState,
+    executionTime: Duration
+  ): (RunState, FailedStep) = (initialRunState, failedStep)
+
+  def onNestedSuccess(
+    resultRunState: RunState,
+    initialRunState: RunState,
+    executionTime: Duration
+  ): RunState = resultRunState.copy(cleanupSteps = release :: resultRunState.cleanupSteps)
+}

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/steps/regular/ResourceStepSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/steps/regular/ResourceStepSpec.scala
@@ -1,0 +1,38 @@
+package com.github.agourlay.cornichon.steps.regular
+
+import java.util.concurrent.ConcurrentSkipListSet
+
+import com.github.agourlay.cornichon.core.{ BasicError, Scenario, Session }
+import com.github.agourlay.cornichon.steps.StepUtilSpec
+import org.scalatest.{ AsyncWordSpec, Matchers }
+
+import scala.concurrent.Future
+import scala.util.Random
+
+class ResourceStepSpec extends AsyncWordSpec with Matchers with StepUtilSpec {
+  "ResourceStep" must {
+    "acquire a resource and release it before the end of the run even if something blows up in the middle" in {
+      val createQueue = EffectStep("create the queue", s ⇒ F(Right(s.addValue("the-queue", queueResource.create()))))
+      val deleteQueue = EffectStep("delete the queue", s ⇒ F(Right { queueResource.delete(s.get("the-queue").right.get); s }))
+      val resourceStep = ResourceStep("ensure queue exists", createQueue, deleteQueue)
+      val fail = EffectStep("go boom", _ ⇒ F(Left(BasicError("sooo basic"))))
+      val s = Scenario("resource step scenario", resourceStep :: fail :: Nil)
+      engine.runScenario(Session.newEmpty)(s).map(_ ⇒ queueResource should be('empty))
+    }
+  }
+
+  private def F[T] = Future.successful[T] _
+  private val queueResource = new QueueManager
+
+  class QueueManager {
+    private val state = new ConcurrentSkipListSet[String]()
+    def create(): String = {
+      val queueName = Random.alphanumeric.take(10).mkString
+      state.add(queueName)
+      queueName
+    }
+    def delete(name: String): Unit = state.remove(name)
+    def isEmpty = state.isEmpty
+  }
+
+}

--- a/cornichon-docs/src/main/tut/custom-steps.md
+++ b/cornichon-docs/src/main/tut/custom-steps.md
@@ -139,3 +139,38 @@ Fortunately a bunch of built-in steps and primitive building blocs are already a
 
 Note for advance users: it is also possible to write custom wrapper steps by implementing ```WrapperStep```.
 
+## ResourceStep
+
+A `ResourceStep` is a way to acquire a resource / create some state and make sure that it gets 
+released / cleaned up before the end of the `Scenario` even if normal control flow is interrupted
+(by an error or a failed assertion for example).
+
+It can be implemented by a pair of `Step`s. One to acquire the resource and another to release it.
+Information can be communicated between the two steps the same way we would with any other `Step`,
+through the `Session`.
+
+So, for example, in a scenario containing:
+
+```scala
+Given I setup_some_fixture_data()
+```
+
+where
+```scala
+def setup_some_fixture_data() = ResourceStep(
+  title = "Set up fixture data"
+  acquire = EffectStep("insert data", { session =>
+    val randomId = insertData()
+    session.addValue("id", randomId)
+  }),
+  release = EffectStep("clean up data", { session =>
+    val randomId = session.get("id").right.get
+    deleteData(randomId)
+  })
+)
+```
+
+we can be sure that the `clean up data` step runs regardless of what happens after `insert data`.
+
+Multiple `ResourceStep`s are allowed in a `Scenario`. In this case, the `release` `Step` 
+of the last `ResourceStep` is run first and we proceed up the `Scenario`. 


### PR DESCRIPTION
Addresses Issue: https://github.com/agourlay/cornichon/issues/147

> The goal is to solve this issue of dangling test resources by introducing this kind of step.
> 
> ```
> case class ResourceStep(
>   resourceName: String,
>   createResource: EffectStep,
>   deleteResource: EffectStep) extends Step
> ```
> Once `createResource` is succesfully executed, `deletedResource` is assured to be executed as well as last step of the current scenario.
> 
> This similar to the semantic of a `finally` bloc.

Tests documenting the behaviour of ResourceStep [here](https://github.com/agourlay/cornichon/compare/master...rjsvaljean:add-resource-step#diff-b3cccf14319fd134bec38f6513acf285R1)