### PR TITLE
Data table improvements

### DIFF
--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/DataTable.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/DataTable.scala
@@ -59,7 +59,7 @@ case class DataTable(headers: Headers, rows: Seq[Row]) {
 
   def objectList: Either[CornichonError, List[JsonObject]] = {
     def parseCol(col: (String, String)) = parseString(col._2).map(col._1 → _)
-    def parseRow(row: Map[String, String]) = row.toList.traverseU(parseCol) map JsonObject.fromIterable
+    def parseRow(row: Map[String, String]) = row.toList.traverseU(parseCol).right map JsonObject.fromIterable
 
     rawStringList traverseU parseRow
   }

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/DataTable.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/DataTable.scala
@@ -6,6 +6,7 @@ import org.parboiled2._
 import com.github.agourlay.cornichon.json.CornichonJson._
 
 import cats.syntax.traverse._
+import cats.syntax.either._
 import cats.instances.list._
 import cats.instances.either._
 
@@ -59,7 +60,7 @@ case class DataTable(headers: Headers, rows: Seq[Row]) {
 
   def objectList: Either[CornichonError, List[JsonObject]] = {
     def parseCol(col: (String, String)) = parseString(col._2).map(col._1 → _)
-    def parseRow(row: Map[String, String]) = row.toList.traverseU(parseCol).right map JsonObject.fromIterable
+    def parseRow(row: Map[String, String]) = row.toList.traverseU(parseCol) map JsonObject.fromIterable
 
     rawStringList traverseU parseRow
   }

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/json/CornichonJson.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/json/CornichonJson.scala
@@ -46,7 +46,7 @@ trait CornichonJson {
   def parseStringUnsafe(s: String): Json = parseString(s).fold(e ⇒ throw e.toException, identity)
 
   def parseDataTable(table: String): Either[CornichonError, List[JsonObject]] =
-    DataTableParser.parse(table).map(_.objectList)
+    DataTableParser.parse(table).flatMap(_.objectList)
 
   def parseDataTableRaw(table: String): Either[CornichonError, List[Map[String, String]]] =
     DataTableParser.parse(table).map(_.rawStringList)

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/json/CornichonJson.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/json/CornichonJson.scala
@@ -8,7 +8,7 @@ import com.github.agourlay.cornichon.core.CornichonError
 import com.github.agourlay.cornichon.dsl.DataTableParser
 import com.github.agourlay.cornichon.resolver.Resolvable
 import gnieh.diffson.circe._
-import io.circe.{ Encoder, Json }
+import io.circe.{ Encoder, Json, JsonObject }
 import io.circe.syntax._
 import sangria.marshalling.MarshallingUtil._
 import sangria.parser.QueryParser
@@ -45,10 +45,10 @@ trait CornichonJson {
 
   def parseStringUnsafe(s: String): Json = parseString(s).fold(e ⇒ throw e.toException, identity)
 
-  def parseDataTable(table: String) =
+  def parseDataTable(table: String): Either[CornichonError, List[JsonObject]] =
     DataTableParser.parse(table).map(_.objectList)
 
-  def parseDataTableUnsafe(table: String) =
+  def parseDataTableUnsafe(table: String): List[JsonObject] =
     parseDataTable(table).fold(e ⇒ throw e.toException, identity)
 
   def parseGraphQLJson(input: String) = QueryParser.parseInput(input) match {

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/json/CornichonJson.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/json/CornichonJson.scala
@@ -48,6 +48,9 @@ trait CornichonJson {
   def parseDataTable(table: String): Either[CornichonError, List[JsonObject]] =
     DataTableParser.parse(table).map(_.objectList)
 
+  def parseDataTableRaw(table: String): Either[CornichonError, List[Map[String, String]]] =
+    DataTableParser.parse(table).map(_.rawStringList)
+
   def parseDataTableUnsafe(table: String): List[JsonObject] =
     parseDataTable(table).fold(e ⇒ throw e.toException, identity)
 

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/dsl/DataTableSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/dsl/DataTableSpec.scala
@@ -2,11 +2,11 @@ package com.github.agourlay.cornichon.dsl
 
 import io.circe.Json
 import org.parboiled2.ParseError
-import org.scalatest.{ Matchers, OptionValues, TryValues, WordSpec }
+import org.scalatest.{Matchers, OptionValues, TryValues, WordSpec, EitherValues}
 
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
-class DataTableSpec extends WordSpec with Matchers with TryValues with OptionValues {
+class DataTableSpec extends WordSpec with Matchers with TryValues with OptionValues with EitherValues {
 
   def referenceParser(input: String) =
     io.circe.parser.parse(input).fold(e ⇒ throw e, identity)
@@ -126,7 +126,7 @@ class DataTableSpec extends WordSpec with Matchers with TryValues with OptionVal
         """
 
       val p = new DataTableParser(input)
-      val objects = parse(p).objectList
+      val objects = parse(p).objectList.right.value
       Json.fromValues(objects.map(Json.fromJsonObject)) should be(referenceParser(expected))
     }
   }

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/dsl/DataTableSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/dsl/DataTableSpec.scala
@@ -2,11 +2,11 @@ package com.github.agourlay.cornichon.dsl
 
 import io.circe.Json
 import org.parboiled2.ParseError
-import org.scalatest.{ Matchers, TryValues, WordSpec }
+import org.scalatest.{ Matchers, OptionValues, TryValues, WordSpec }
 
 import scala.util.{ Failure, Success }
 
-class DataTableSpec extends WordSpec with Matchers with TryValues {
+class DataTableSpec extends WordSpec with Matchers with TryValues with OptionValues {
 
   def referenceParser(input: String) =
     io.circe.parser.parse(input).fold(e ⇒ throw e, identity)
@@ -26,7 +26,7 @@ class DataTableSpec extends WordSpec with Matchers with TryValues {
                   """
 
       val p = new DataTableParser(input)
-      p.dataTableRule.run().isFailure should be(true)
+      p.dataTableRule.run().map(_.objectList).isFailure should be(true)
     }
 
     "process a single line with 1 value without new line on first" in {
@@ -34,14 +34,8 @@ class DataTableSpec extends WordSpec with Matchers with TryValues {
                       |  "John"  |
                   """
 
-      val expected = DataTable(
-        headers = Headers(Seq("Name")),
-        rows = Seq(
-          Row(Seq(Json.fromString("John")))
-        )
-      )
-      val p = new DataTableParser(input)
-      parse(p) should be(expected)
+      parse(new DataTableParser(input)).objectList should be(
+        List(Json.obj("Name" → Json.fromString("John")).asObject.value))
     }
 
     "process a single line with 1 value" in {
@@ -50,14 +44,8 @@ class DataTableSpec extends WordSpec with Matchers with TryValues {
         |  "John"  |
         """
 
-      val expected = DataTable(
-        headers = Headers(Seq("Name")),
-        rows = Seq(
-          Row(Seq(Json.fromString("John")))
-        )
-      )
-      val p = new DataTableParser(input)
-      parse(p) should be(expected)
+      parse(new DataTableParser(input)).objectList should be(
+        List(Json.obj("Name" → Json.fromString("John")).asObject.value))
     }
 
     "process a single line with 2 values" in {
@@ -66,14 +54,11 @@ class DataTableSpec extends WordSpec with Matchers with TryValues {
         |  "John" |   50    |
       """
 
-      val expected = DataTable(
-        headers = Headers(Seq("Name", "Age")),
-        rows = Seq(
-          Row(Seq(Json.fromString("John"), Json.fromInt(50)))
-        )
-      )
-      val p = new DataTableParser(input)
-      parse(p) should be(expected)
+      parse(new DataTableParser(input)).objectList should be(
+        List(Json.obj(
+          "Name" → Json.fromString("John"),
+          "Age" → Json.fromInt(50)
+        ).asObject.value))
     }
 
     "process string values nd headers with unicode characters and escaping" in {
@@ -83,15 +68,11 @@ class DataTableSpec extends WordSpec with Matchers with TryValues {
           | "öÖß \u00DF \" test " |   50                     |
         """
 
-      val expected = DataTable(
-        headers = Headers(Seq("Name", """Größe ß " | test""")),
-        rows = Seq(
-          Row(Seq(Json.fromString("""öÖß ß " test """), Json.fromInt(50)))
-        )
-      )
-
-      val p = new DataTableParser(input)
-      parse(p) should be(expected)
+      parse(new DataTableParser(input)).objectList should be(
+        List(Json.obj(
+          "Name" → Json.fromString("öÖß \u00DF \" test "),
+          "Größe \u00DF \" | test" → Json.fromInt(50)
+        ).asObject.value))
     }
 
     "process multiline string" in {
@@ -101,15 +82,16 @@ class DataTableSpec extends WordSpec with Matchers with TryValues {
         | "Bob"  |   11   |
       """
 
-      val expected = DataTable(
-        headers = Headers(Seq("Name", "Age")),
-        rows = Seq(
-          Row(Seq(Json.fromString("John"), Json.fromInt(50))),
-          Row(Seq(Json.fromString("Bob"), Json.fromInt(11)))
-        )
-      )
-      val p = new DataTableParser(input)
-      parse(p) should be(expected)
+      parse(new DataTableParser(input)).objectList should be(
+        List(
+          Json.obj(
+            "Name" → Json.fromString("John"),
+            "Age" → Json.fromInt(50)
+          ).asObject.value,
+          Json.obj(
+            "Name" → Json.fromString("Bob"),
+            "Age" → Json.fromInt(11)
+          ).asObject.value))
     }
 
     "notify malformed table" in {

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/dsl/DataTableSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/dsl/DataTableSpec.scala
@@ -26,7 +26,7 @@ class DataTableSpec extends WordSpec with Matchers with TryValues with OptionVal
                   """
 
       val p = new DataTableParser(input)
-      p.dataTableRule.run().map(_.objectList).isFailure should be(true)
+      p.dataTableRule.run().map(_.objectList.right.value).isFailure should be(true)
     }
 
     "process a single line with 1 value without new line on first" in {
@@ -34,7 +34,7 @@ class DataTableSpec extends WordSpec with Matchers with TryValues with OptionVal
                       |  "John"  |
                   """
 
-      parse(new DataTableParser(input)).objectList should be(
+      parse(new DataTableParser(input)).objectList.right.value should be(
         List(Json.obj("Name" → Json.fromString("John")).asObject.value))
     }
 
@@ -44,7 +44,7 @@ class DataTableSpec extends WordSpec with Matchers with TryValues with OptionVal
         |  "John"  |
         """
 
-      parse(new DataTableParser(input)).objectList should be(
+      parse(new DataTableParser(input)).objectList.right.value should be(
         List(Json.obj("Name" → Json.fromString("John")).asObject.value))
     }
 
@@ -54,7 +54,7 @@ class DataTableSpec extends WordSpec with Matchers with TryValues with OptionVal
         |  "John" |   50    |
       """
 
-      parse(new DataTableParser(input)).objectList should be(
+      parse(new DataTableParser(input)).objectList.right.value should be(
         List(Json.obj(
           "Name" → Json.fromString("John"),
           "Age" → Json.fromInt(50)
@@ -68,7 +68,7 @@ class DataTableSpec extends WordSpec with Matchers with TryValues with OptionVal
           | "öÖß \u00DF \" test " |   50                     |
         """
 
-      parse(new DataTableParser(input)).objectList should be(
+      parse(new DataTableParser(input)).objectList.right.value should be(
         List(Json.obj(
           "Name" → Json.fromString("öÖß \u00DF \" test "),
           "Größe \u00DF \" | test" → Json.fromInt(50)
@@ -82,7 +82,7 @@ class DataTableSpec extends WordSpec with Matchers with TryValues with OptionVal
         | "Bob"  |   11   |
       """
 
-      parse(new DataTableParser(input)).objectList should be(
+      parse(new DataTableParser(input)).objectList.right.value should be(
         List(
           Json.obj(
             "Name" → Json.fromString("John"),

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/json/CornichonJsonSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/json/CornichonJsonSpec.scala
@@ -135,8 +135,8 @@ class CornichonJsonSpec extends WordSpec
             | Bob  |   11   |              |
           """
         ) should beRight(List(
-            Map("2LettersName" → "false"),
-            Map("Age" → "11", "Name" → "Bob")))
+          Map("2LettersName" → "false"),
+          Map("Age" → "11", "Name" → "Bob")))
       }
     }
 

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/json/CornichonJsonSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/json/CornichonJsonSpec.scala
@@ -7,7 +7,7 @@ import cats.instances.double._
 import cats.instances.boolean._
 import cats.instances.int._
 import org.scalatest.prop.PropertyChecks
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.{ Matchers, OptionValues, WordSpec }
 import cats.instances.bigDecimal._
 import cats.scalatest.{ EitherMatchers, EitherValues }
 
@@ -16,7 +16,8 @@ class CornichonJsonSpec extends WordSpec
   with PropertyChecks
   with CornichonJson
   with EitherValues
-  with EitherMatchers {
+  with EitherMatchers
+  with OptionValues {
 
   def refParser(input: String) =
     io.circe.parser.parse(input).fold(e ⇒ throw e, identity)
@@ -82,7 +83,6 @@ class CornichonJsonSpec extends WordSpec
       }
 
       "parse data table" in {
-
         val expected =
           """
             |[
@@ -104,6 +104,27 @@ class CornichonJsonSpec extends WordSpec
            | "John" |   50   |    false     |
            | "Bob"  |   11   |    true      |
          """) should beRight(refParser(expected))
+      }
+
+      "parse data table with empty cell values" in {
+        parseDataTable(
+          """
+            |  Name  |   Age  | 2LettersName |
+            |        |        |    false     |
+            | "Bob"  |   11   |              |
+          """
+        ) should beRight(List(
+            """
+            {
+              "2LettersName" : false
+            }
+          """,
+            """
+            {
+              "Age": 11,
+              "Name": "Bob"
+            }
+          """) map (refParser(_).asObject.value))
       }
     }
 

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/json/CornichonJsonSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/json/CornichonJsonSpec.scala
@@ -114,17 +114,29 @@ class CornichonJsonSpec extends WordSpec
             | "Bob"  |   11   |              |
           """
         ) should beRight(List(
-            """
+          """
             {
               "2LettersName" : false
             }
           """,
-            """
+          """
             {
               "Age": 11,
               "Name": "Bob"
             }
           """) map (refParser(_).asObject.value))
+      }
+
+      "parse data table as a map of raw string values" in {
+        parseDataTableRaw(
+          """
+            | Name |   Age  | 2LettersName |
+            |      |        |    false     |
+            | Bob  |   11   |              |
+          """
+        ) should beRight(List(
+            Map("2LettersName" → "false"),
+            Map("Age" → "11", "Name" → "Bob")))
       }
     }
 


### PR DESCRIPTION
Improvements include:

* Empty cell value support
* Ability to get the raw cell values as a string (without parsing every cell value as a JSON)

Both of the features are very useful for custom parsers that use custom cell value validation and interpretation mechanism.

Here is an example of data table syntax that added by this PR:

```
| Name |   Age  | 2LettersName |
|      |        |    false     |
| Bob  |   11   |              |
```