### PR TITLE
Added ability to focus specific scenarios

### DIFF
--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Engine.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Engine.scala
@@ -23,11 +23,11 @@ import FutureEitherTHelpers._
 
 class Engine(stepPreparers: List[StepPreparer])(implicit scheduler: Scheduler) {
 
-  def runScenario(session: Session, finallySteps: List[Step] = Nil, featureIgnored: Boolean = false)(scenario: Scenario): Future[ScenarioReport] =
-    runScenarioTask(session, finallySteps, featureIgnored)(scenario).runAsync
+  def runScenario(session: Session, finallySteps: List[Step] = Nil, featureIgnored: Boolean = false, focusedScenarios: Set[String] = Set.empty)(scenario: Scenario): Future[ScenarioReport] =
+    runScenarioTask(session, finallySteps, featureIgnored, focusedScenarios)(scenario).runAsync
 
-  def runScenarioTask(session: Session, finallySteps: List[Step] = Nil, featureIgnored: Boolean = false)(scenario: Scenario): Task[ScenarioReport] =
-    if (featureIgnored || scenario.ignored)
+  def runScenarioTask(session: Session, finallySteps: List[Step] = Nil, featureIgnored: Boolean = false, focusedScenarios: Set[String] = Set.empty)(scenario: Scenario): Task[ScenarioReport] =
+    if (featureIgnored || scenario.ignored || (focusedScenarios.nonEmpty && !focusedScenarios.contains(scenario.name)))
       Task.delay(IgnoreScenarioReport(scenario.name, session))
     else if (scenario.pending)
       Task.delay(PendingScenarioReport(scenario.name, session))

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Engine.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Engine.scala
@@ -23,13 +23,13 @@ import FutureEitherTHelpers._
 
 class Engine(stepPreparers: List[StepPreparer])(implicit scheduler: Scheduler) {
 
-  def runScenario(session: Session, finallySteps: List[Step] = Nil, featureIgnored: Boolean = false, focusedScenarios: Set[String] = Set.empty)(scenario: Scenario): Future[ScenarioReport] =
-    runScenarioTask(session, finallySteps, featureIgnored, focusedScenarios)(scenario).runAsync
+  def runScenario(session: Session, context: ScenarioExecutionContext = ScenarioExecutionContext.empty)(scenario: Scenario): Future[ScenarioReport] =
+    runScenarioTask(session, context)(scenario).runAsync
 
-  def runScenarioTask(session: Session, finallySteps: List[Step] = Nil, featureIgnored: Boolean = false, focusedScenarios: Set[String] = Set.empty)(scenario: Scenario): Task[ScenarioReport] =
-    if (featureIgnored || scenario.ignored || (focusedScenarios.nonEmpty && !focusedScenarios.contains(scenario.name)))
+  def runScenarioTask(session: Session, context: ScenarioExecutionContext = ScenarioExecutionContext.empty)(scenario: Scenario): Task[ScenarioReport] =
+    if (context isIgnored scenario)
       Task.delay(IgnoreScenarioReport(scenario.name, session))
-    else if (scenario.pending)
+    else if (context isPending scenario)
       Task.delay(PendingScenarioReport(scenario.name, session))
     else {
       val titleLog = ScenarioTitleLogInstruction(s"Scenario : ${scenario.name}", initMargin)
@@ -37,12 +37,12 @@ class Engine(stepPreparers: List[StepPreparer])(implicit scheduler: Scheduler) {
       runSteps(initialRunState).flatMap {
         case (mainState, mainRunReport) ⇒
           val stateAndReporAfterEndSteps = {
-            if (finallySteps.isEmpty && mainState.cleanupSteps.isEmpty)
+            if (context.finallySteps.isEmpty && mainState.cleanupSteps.isEmpty)
               Task.delay((mainState, validDone))
-            else if (finallySteps.nonEmpty && mainState.cleanupSteps.isEmpty) {
+            else if (context.finallySteps.nonEmpty && mainState.cleanupSteps.isEmpty) {
               // Reuse mainline session
               val finallyLog = InfoLogInstruction("finally steps", initMargin + 1)
-              val finallyRunState = mainState.withSteps(finallySteps).withLog(finallyLog)
+              val finallyRunState = mainState.withSteps(context.finallySteps).withLog(finallyLog)
               runSteps(finallyRunState).map {
                 case (finallyState, finallyReport) ⇒ (mainState.combine(finallyState), finallyReport.toValidatedNel)
               }

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Models.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Models.scala
@@ -5,6 +5,8 @@ case class FeatureDef(name: String, scenarios: List[Scenario], ignored: Boolean 
     scenarios.map(s ⇒ s.name).distinct.length == scenarios.length,
     s"Scenarios name must be unique within a Feature - error caused by duplicated declaration of scenarios '${scenarios.map(s ⇒ s.name).diff(scenarios.map(s ⇒ s.name).distinct).mkString(", ")}'"
   )
+
+  val focusedScenarios = scenarios.collect { case s if s.focused ⇒ s.name }.toSet
 }
 
 case class Scenario(name: String, steps: List[Step], ignored: Boolean = false, pending: Boolean = false, focused: Boolean = false)

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Models.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Models.scala
@@ -7,4 +7,4 @@ case class FeatureDef(name: String, scenarios: List[Scenario], ignored: Boolean 
   )
 }
 
-case class Scenario(name: String, steps: List[Step], ignored: Boolean = false, pending: Boolean = false)
+case class Scenario(name: String, steps: List[Step], ignored: Boolean = false, pending: Boolean = false, focused: Boolean = false)

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/ScenarioExecutionContext.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/ScenarioExecutionContext.scala
@@ -1,0 +1,13 @@
+package com.github.agourlay.cornichon.core
+
+case class ScenarioExecutionContext(finallySteps: List[Step] = Nil, featureIgnored: Boolean = false, focusedScenarios: Set[String] = Set.empty) {
+  def isIgnored(scenario: Scenario) =
+    featureIgnored || scenario.ignored || (focusedScenarios.nonEmpty && !focusedScenarios.contains(scenario.name))
+
+  def isPending(scenario: Scenario) =
+    scenario.pending
+}
+
+object ScenarioExecutionContext {
+  val empty = ScenarioExecutionContext()
+}

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/Dsl.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/Dsl.scala
@@ -38,6 +38,7 @@ trait Dsl extends ProvidedInstances {
 
   private[dsl] case class ScenarioBuilder(name: String, ignored: Boolean = false, focus: Boolean = false) {
     def ignoredBecause(reason: String) = copy(ignored = true)
+    /** Focus on this scenario ignoring all other scenarios withing a `Feature` */
     def focused = copy(focus = true)
     def pending = ScenarioDef(name, Nil, pending = true)
   }

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/Dsl.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/Dsl.scala
@@ -36,13 +36,14 @@ trait Dsl extends ProvidedInstances {
 
   def Scenario(name: String) = ScenarioBuilder(name)
 
-  private[dsl] case class ScenarioBuilder(name: String, ignored: Boolean = false) {
+  private[dsl] case class ScenarioBuilder(name: String, ignored: Boolean = false, focus: Boolean = false) {
     def ignoredBecause(reason: String) = copy(ignored = true)
+    def focused = copy(focus = true)
     def pending = ScenarioDef(name, Nil, pending = true)
   }
 
   implicit def scenarioBuilder(s: ScenarioBuilder): BodyElementCollector[Step, ScenarioDef] =
-    BodyElementCollector[Step, ScenarioDef](steps ⇒ ScenarioDef(s.name, steps, s.ignored))
+    BodyElementCollector[Step, ScenarioDef](steps ⇒ ScenarioDef(s.name, steps, s.ignored, focused = s.focus))
 
   sealed trait Starters extends Dynamic {
     def name: String

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/feature/BaseFeature.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/feature/BaseFeature.scala
@@ -39,9 +39,9 @@ trait BaseFeature extends HttpDsl with JsonDsl with Dsl {
   lazy val placeholderResolver = new PlaceholderResolver(registerExtractors)
   lazy val matcherResolver = new MatcherResolver(registerMatcher)
 
-  def runScenario(s: Scenario) = {
+  def runScenario(s: Scenario, focusedScenarios: Set[String]) = {
     println(s"Starting scenario '${s.name}'")
-    engine.runScenario(Session.newEmpty, afterEachScenario.toList, feature.ignored) {
+    engine.runScenario(Session.newEmpty, afterEachScenario.toList, feature.ignored, focusedScenarios) {
       s.copy(steps = beforeEachScenario.toList ++ s.steps)
     }
   }

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/feature/BaseFeature.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/feature/BaseFeature.scala
@@ -39,9 +39,12 @@ trait BaseFeature extends HttpDsl with JsonDsl with Dsl {
   lazy val placeholderResolver = new PlaceholderResolver(registerExtractors)
   lazy val matcherResolver = new MatcherResolver(registerMatcher)
 
-  def runScenario(s: Scenario, focusedScenarios: Set[String]) = {
+  def runScenario(s: Scenario) = {
+    val context = ScenarioExecutionContext(afterEachScenario.toList, feature.ignored, feature.focusedScenarios)
+
     println(s"Starting scenario '${s.name}'")
-    engine.runScenario(Session.newEmpty, afterEachScenario.toList, feature.ignored, focusedScenarios) {
+
+    engine.runScenario(Session.newEmpty, context) {
       s.copy(steps = beforeEachScenario.toList ++ s.steps)
     }
   }

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/core/EngineSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/core/EngineSpec.scala
@@ -56,7 +56,7 @@ class EngineSpec extends AsyncWordSpec with Matchers {
         val mainStep = AssertStep("main step", s ⇒ GenericEqualityAssertion(true, false))
         val finallyStep = AssertStep("finally step", s ⇒ GenericEqualityAssertion(true, false))
         val s = Scenario("test", mainStep :: Nil)
-        engine.runScenario(Session.newEmpty, finallyStep :: Nil)(s).map {
+        engine.runScenario(Session.newEmpty, ScenarioExecutionContext(finallyStep :: Nil))(s).map {
           case f: FailureScenarioReport ⇒
             withClue(f.msg) {
               f.msg should be(
@@ -120,8 +120,9 @@ class EngineSpec extends AsyncWordSpec with Matchers {
           }
         )
 
-        val s = Scenario("scenario with effects", List.fill(effectNumber)(effect))
-        engine.runScenario(Session.newEmpty, List.fill(effectNumber)(effect))(s).map { res ⇒
+        val context = ScenarioExecutionContext(List.fill(effectNumber)(effect))
+        val s = Scenario("scenario with effects", context.finallySteps)
+        engine.runScenario(Session.newEmpty, context)(s).map { res ⇒
           res.isSuccess should be(true)
           uglyCounter.get() should be(effectNumber * 2)
           res.logs.size should be(effectNumber * 2 + 2)

--- a/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/experimental/sbtinterface/SbtCornichonTask.scala
+++ b/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/experimental/sbtinterface/SbtCornichonTask.scala
@@ -47,14 +47,15 @@ class SbtCornichonTask(task: TaskDef) extends Task {
         println(SuccessLogInstruction(s"${feature.name}:", 0).colorized)
         // Run 'before feature' hooks
         baseFeature.beforeFeature.foreach(f ⇒ f())
+        val focusedScenarios = feature.scenarios.collect { case s if s.focused ⇒ s.name }.toSet
         val scenarioResults = {
           if (baseFeature.executeScenariosInParallel)
-            Future.traverse(feature.scenarios)(runScenario(baseFeature, eventHandler))
+            Future.traverse(feature.scenarios)(runScenario(baseFeature, eventHandler, focusedScenarios))
           else
             feature.scenarios.foldLeft(Future.successful(List.empty[ScenarioReport])) { (r, s) ⇒
               for {
                 acc ← r
-                current ← runScenario(baseFeature, eventHandler)(s)
+                current ← runScenario(baseFeature, eventHandler, focusedScenarios)(s)
               } yield acc :+ current
             }
         }
@@ -69,9 +70,9 @@ class SbtCornichonTask(task: TaskDef) extends Task {
     )
   }
 
-  def runScenario(feature: BaseFeature, eventHandler: EventHandler)(s: Scenario): Future[ScenarioReport] = {
+  def runScenario(feature: BaseFeature, eventHandler: EventHandler, focusedScenarios: Set[String])(s: Scenario): Future[ScenarioReport] = {
     val startTS = System.currentTimeMillis()
-    feature.runScenario(s).map { r ⇒
+    feature.runScenario(s, focusedScenarios).map { r ⇒
       //Generate result event
       val endTS = System.currentTimeMillis()
       eventHandler.handle(eventBuilder(r, endTS - startTS))

--- a/cornichon-experimental/src/test/scala/com/github/agourlay/cornichon/experimental/examples/FocusedExperimentalScenario.scala
+++ b/cornichon-experimental/src/test/scala/com/github/agourlay/cornichon/experimental/examples/FocusedExperimentalScenario.scala
@@ -1,0 +1,27 @@
+package com.github.agourlay.cornichon.experimental.examples
+
+import com.github.agourlay.cornichon.experimental.CornichonFeature
+
+import scala.concurrent.duration._
+
+class FocusedExperimentalScenario extends CornichonFeature {
+  def feature = Feature("feature/scenario focus") {
+    Scenario("Scenario 1") {
+      Given I wait(10 hours)
+      And I print_step("Scenario 1 is finished")
+    }
+
+    Scenario("Scenario 2").focused {
+      And I print_step("Scenario 2 is finished")
+    }
+
+    Scenario("Scenario 3") {
+      Given I wait(10 hours)
+      And I print_step("Scenario 3 is finished")
+    }
+
+    Scenario("Scenario 4").focused {
+      And I print_step("Scenario 4 is finished")
+    }
+  }
+}

--- a/cornichon-scalatest/src/main/scala/com/github/agourlay/cornichon/scalatest/ScalatestFeature.scala
+++ b/cornichon-scalatest/src/main/scala/com/github/agourlay/cornichon/scalatest/ScalatestFeature.scala
@@ -43,14 +43,16 @@ trait ScalatestFeature extends AsyncWordSpecLike with BeforeAndAfterAll with Par
       }
     case Success(feat) ⇒
       feat.name should {
+        val focusedScenarios = feat.scenarios.collect { case s if s.focused ⇒ s.name }.toSet
+
         feat.scenarios.foreach { s ⇒
-          if (feat.ignored || s.ignored)
+          if (feat.ignored || s.ignored || (focusedScenarios.nonEmpty && !focusedScenarios.contains(s.name)))
             s.name ignore { Future.successful(Succeeded) }
           else if (s.pending)
             s.name in pending
           else
             s.name in {
-              runScenario(s).map {
+              runScenario(s, focusedScenarios).map {
                 case s: SuccessScenarioReport ⇒
                   if (s.shouldShowLogs) printLogs(s.logs)
                   assert(true)

--- a/cornichon-scalatest/src/main/scala/com/github/agourlay/cornichon/scalatest/ScalatestFeature.scala
+++ b/cornichon-scalatest/src/main/scala/com/github/agourlay/cornichon/scalatest/ScalatestFeature.scala
@@ -41,18 +41,17 @@ trait ScalatestFeature extends AsyncWordSpecLike with BeforeAndAfterAll with Par
           )
         }
       }
+
     case Success(feat) ⇒
       feat.name should {
-        val focusedScenarios = feat.scenarios.collect { case s if s.focused ⇒ s.name }.toSet
-
         feat.scenarios.foreach { s ⇒
-          if (feat.ignored || s.ignored || (focusedScenarios.nonEmpty && !focusedScenarios.contains(s.name)))
+          if (feat.ignored || s.ignored || (feat.focusedScenarios.nonEmpty && !feat.focusedScenarios.contains(s.name)))
             s.name ignore { Future.successful(Succeeded) }
           else if (s.pending)
             s.name in pending
           else
             s.name in {
-              runScenario(s, focusedScenarios).map {
+              runScenario(s).map {
                 case s: SuccessScenarioReport ⇒
                   if (s.shouldShowLogs) printLogs(s.logs)
                   assert(true)

--- a/cornichon-scalatest/src/test/scala/com/github/agourlay/cornichon/examples/FocusedScenario.scala
+++ b/cornichon-scalatest/src/test/scala/com/github/agourlay/cornichon/examples/FocusedScenario.scala
@@ -1,0 +1,27 @@
+package com.github.agourlay.cornichon.examples
+
+import com.github.agourlay.cornichon.CornichonFeature
+
+import scala.concurrent.duration._
+
+class FocusedScenario extends CornichonFeature {
+  def feature = Feature("feature/scenario focus") {
+    Scenario("Scenario 1") {
+      Given I wait(10 hours)
+      And I print_step("Scenario 1 is finished")
+    }
+
+    Scenario("Scenario 2").focused {
+      And I print_step("Scenario 2 is finished")
+    }
+
+    Scenario("Scenario 3") {
+      Given I wait(10 hours)
+      And I print_step("Scenario 3 is finished")
+    }
+
+    Scenario("Scenario 4").focused {
+      And I print_step("Scenario 4 is finished")
+    }
+  }
+}


### PR DESCRIPTION
Quite often I find myself in a situation where I'm working on a big feature and would like to quickly add new a scenario. As I'm working on it and have `sbt ~testOnly *FooFeature` in the background, it takes a lot of time to execute all existing scenarios including the new one which I'm working on.

This small addition makes it a bit easier to quickly pick a particular scenario and run it ignoring all other scenarios within a feature. Here is an example:

```scala
class FocusedScenario extends CornichonFeature {
  def feature = Feature("feature/scenario focus") {
    Scenario("Scenario 1") {
      Given I wait(10 hours)
      And I print_step("Scenario 1 is finished")
    }

    Scenario("My brand new scenario!").focused {
      And I print_step("Scenario 2 is still WIP")
    }

    Scenario("Scenario 3") {
      Given I wait(5 minutes)
      And I print_step("Scenario 3 is finished")
    }

    Scenario("Scenario 4") {
      Given I wait(20 hours)
      And I print_step("Scenario 4 is finished")
    }
  }
}
```

When I run `FocusedScenario`, only `"My brand new scenario!"` scenario is tested. All other scenarios are ignored.

This PR is just an implementation idea. I'm wondering what you think about it. Do you think it might be suitable for inclusion?
 