### PR TITLE
Add 400 status and response bodies to HttpMockServer

### DIFF
--- a/cornichon-http-mock/src/main/scala/com/github/agourlay/cornichon/http/server/MockServerResultsHolder.scala
+++ b/cornichon-http-mock/src/main/scala/com/github/agourlay/cornichon/http/server/MockServerResultsHolder.scala
@@ -1,7 +1,7 @@
 package com.github.agourlay.cornichon.http.server
 
 import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 
 import com.github.agourlay.cornichon.http
 import scala.collection.JavaConverters._
@@ -10,6 +10,8 @@ class MockServerResultsHolder {
 
   private val receivedRequests = new ConcurrentLinkedQueue[http.HttpRequest[String]]()
   private val errorMode = new AtomicBoolean(false)
+  private val badRequestMode = new AtomicBoolean(false)
+  private val response = new AtomicReference[String]("")
 
   def getReceivedRequest = receivedRequests.asScala.toVector
 
@@ -22,6 +24,18 @@ class MockServerResultsHolder {
   }
 
   def getErrorMode = errorMode.get
+
+  def toggleBadRequestMode() = synchronized {
+    badRequestMode.set(!badRequestMode.get())
+  }
+
+  def getBadRequestMode = badRequestMode.get
+
+  def setResponse(newResponse: String) = synchronized {
+    response.set(newResponse)
+  }
+
+  def getResponse: String = response.get
 
 }
 


### PR DESCRIPTION
This enhances the HttpMockServer so that it can send prepared responses, and the 400 status code.

For the example, I added some comments, but I'm not sure if that is something that you usually do. I've added them as scala comments, but I could also use `AttachAs` (or just remove them).