### PR TITLE
HttpMock tries its best to find an open port

### DIFF
--- a/cornichon-http-mock/src/main/scala/com/github/agourlay/cornichon/http/server/MockHttpServer.scala
+++ b/cornichon-http-mock/src/main/scala/com/github/agourlay/cornichon/http/server/MockHttpServer.scala
@@ -2,23 +2,45 @@ package com.github.agourlay.cornichon.http.server
 
 import java.net.NetworkInterface
 
+import com.github.agourlay.cornichon.core.CornichonError
 import com.github.agourlay.cornichon.dsl.CloseableResource
+import fs2.{ Scheduler, Strategy }
 import monix.eval.Task
 import org.http4s.HttpService
 import org.http4s.server.blaze.BlazeBuilder
 
 import scala.collection.JavaConverters._
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.duration._
 import scala.util.Random
 
-class MockHttpServer(interface: Option[String], port: Option[Range], mockService: HttpService) extends HttpServer {
+class MockHttpServer(interface: Option[String], port: Option[Range], mockService: HttpService, maxRetries: Int = 5) extends HttpServer {
+
+  implicit val strategy = Strategy.fromExecutionContext(ExecutionContext.Implicits.global)
+  implicit val scheduler = Scheduler.fromFixedDaemonPool(1)
 
   private val selectedInterface = interface.getOrElse(bestInterface())
-  // TODO handle case of random port from range taken, retry?
-  private val selectedPort = port.fold(0)(r ⇒ Random.shuffle(r.toList).head)
+  private val randomPortOrder = port.fold(List(0))(r ⇒ Random.shuffle(r.toList))
 
-  def startServer() =
+  def startServer(): Future[(String, CloseableResource)] =
+    if (randomPortOrder.isEmpty)
+      Future.failed(MockHttpServerError.toException)
+    else
+      startServerTryPorts(randomPortOrder).unsafeRunAsyncFuture()
+
+  private def startServerTryPorts(ports: List[Int], retry: Int = 0): fs2.Task[(String, CloseableResource)] =
+    startBlazeServer(ports.head).handleWith {
+      case _: java.net.BindException if ports.length > 1 ⇒
+        startServerTryPorts(ports.tail, retry)
+      case _: java.net.BindException if retry < maxRetries ⇒
+        val sleepFor = retry + 1
+        println(s"Could not start server on any port. Retrying in $sleepFor seconds...")
+        startServerTryPorts(randomPortOrder, retry + 1).schedule((retry + 1) seconds)
+    }
+
+  private def startBlazeServer(port: Int): fs2.Task[(String, CloseableResource)] =
     BlazeBuilder
-      .bindHttp(selectedPort, selectedInterface)
+      .bindHttp(port, selectedInterface)
       .mountService(mockService, "/")
       .start
       .map { serverBinding ⇒
@@ -27,7 +49,7 @@ class MockHttpServer(interface: Option[String], port: Option[Range], mockService
           def stopResource() = Task.fromFuture(serverBinding.shutdown.unsafeRunAsyncFuture())
         }
         (fullAddress, closeable)
-      }.unsafeRunAsyncFuture()
+      }
 
   private def bestInterface(): String =
     NetworkInterface.getNetworkInterfaces.asScala
@@ -36,4 +58,8 @@ class MockHttpServer(interface: Option[String], port: Option[Range], mockService
       .find(i ⇒ i.isSiteLocalAddress)
       .map(_.getHostAddress).getOrElse("localhost")
 
+}
+
+case object MockHttpServerError extends CornichonError {
+  def baseErrorMessage = "the range of ports provided for the HTTP mock is invalid"
 }

--- a/cornichon-http-mock/src/test/scala/com/github/agourlay/cornichon/http/MockServerExample.scala
+++ b/cornichon-http-mock/src/test/scala/com/github/agourlay/cornichon/http/MockServerExample.scala
@@ -7,7 +7,7 @@ class MockServerExample extends CornichonFeature with HttpMockDsl {
 
   override lazy val requestTimeout = 3.seconds
 
-  def HttpMock = HttpListenTo(interface = None, portRange = Some(Range(8080, 9000)))_
+  def HttpMock = HttpListenTo(interface = None, portRange = Some(Range(8080, 8083)))_
 
   def feature =
     Feature("Cornichon feature mock server examples") {
@@ -241,7 +241,6 @@ class MockServerExample extends CornichonFeature with HttpMockDsl {
           )
         }
       }
-
 
       Scenario("httpListen blocks can be nested in one another") {
         HttpMock("first-server") {


### PR DESCRIPTION
@cneijenhuis I pulled some of your work from https://github.com/agourlay/cornichon/compare/master...cneijenhuis:http-mock-port to check it myself :)

Adding the Task re-scheduling seems to do the trick. Let's see how it rolls on TravisCI. 