### PR TITLE
Separation between base and http feature/dsl

### DIFF
--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/feature/HttpFeature.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/feature/HttpFeature.scala
@@ -1,0 +1,43 @@
+package com.github.agourlay.cornichon.feature
+
+import cats.syntax.either._
+import com.github.agourlay.cornichon.core.SessionKey
+import com.github.agourlay.cornichon.dsl.Dsl.{FromSessionSetter, save_from_session}
+import com.github.agourlay.cornichon.http.HttpService.SessionKeys.lastResponseBodyKey
+import com.github.agourlay.cornichon.http.{HttpDsl, HttpService, QueryGQL}
+import com.github.agourlay.cornichon.json.CornichonJson.jsonStringValue
+import com.github.agourlay.cornichon.json.JsonSteps.JsonStepBuilder
+import com.github.agourlay.cornichon.json.{JsonDsl, JsonPath}
+
+import scala.concurrent.duration.FiniteDuration
+
+trait HttpFeature extends HttpDsl with JsonDsl with BaseFeature {
+
+  lazy val requestTimeout = config.requestTimeout
+  lazy val baseUrl = config.baseUrl
+
+  def httpServiceByURL(baseUrl: String, timeout: FiniteDuration = requestTimeout) =
+    new HttpService(baseUrl, timeout, HttpDsl.globalHttpclient, placeholderResolver, config)
+
+  lazy val http = httpServiceByURL(baseUrl, requestTimeout)
+
+  def query_gql(url: String) = QueryGQL(url, QueryGQL.emptyDocument, None, None, Nil, Nil)
+
+  //FIXME the body is expected to always contains JSON currently
+  def body = JsonStepBuilder(placeholderResolver, matcherResolver, SessionKey(lastResponseBodyKey), Some("response body"))
+
+  def save_body(target: String) = save_body_path(JsonPath.root → target)
+
+  def save_body_path(args: (String, String)*) = {
+    val inputs = args.map {
+      case (path, target) ⇒ FromSessionSetter(lastResponseBodyKey, (session, s) ⇒ {
+        for {
+          resolvedPath ← placeholderResolver.fillPlaceholders(path)(session)
+          jsonPath ← JsonPath.parse(resolvedPath)
+          json ← jsonPath.run(s)
+        } yield jsonStringValue(json)
+      }, target)
+    }
+    save_from_session(inputs)
+  }
+}

--- a/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/experimental/CornichonFeature.scala
+++ b/cornichon-experimental/src/main/scala/com/github/agourlay/cornichon/experimental/CornichonFeature.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.experimental
 
-import com.github.agourlay.cornichon.feature.BaseFeature
+import com.github.agourlay.cornichon.feature.{ BaseFeature, HttpFeature }
 
-trait CornichonFeature extends BaseFeature
+trait CornichonBaseFeature extends BaseFeature
+trait CornichonFeature extends HttpFeature

--- a/cornichon-scalatest/src/main/scala/com/github/agourlay/cornichon/CornichonFeature.scala
+++ b/cornichon-scalatest/src/main/scala/com/github/agourlay/cornichon/CornichonFeature.scala
@@ -1,6 +1,7 @@
 package com.github.agourlay.cornichon
 
-import com.github.agourlay.cornichon.feature.BaseFeature
+import com.github.agourlay.cornichon.feature.{ BaseFeature, HttpFeature }
 import com.github.agourlay.cornichon.scalatest.ScalatestFeature
 
-trait CornichonFeature extends BaseFeature with ScalatestFeature
+trait CornichonBaseFeature extends BaseFeature with ScalatestFeature
+trait CornichonFeature extends HttpFeature with ScalatestFeature


### PR DESCRIPTION
manage the cornichon/core with a separation in transport concern
we could enable the use of TCP API as well.