### PR TITLE
add isNot in JsonSteps

### DIFF
--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/json/JsonSteps.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/json/JsonSteps.scala
@@ -70,7 +70,10 @@ object JsonSteps {
         is(a)
     }
 
-    def is[A: Show: Resolvable: Encoder](expected: A): AssertStep = {
+    def is[A: Show: Resolvable: Encoder](expected: A): AssertStep = isImpl(expected)
+    def isNot[A: Show: Resolvable: Encoder](expected: A): AssertStep = isImpl(expected, negate = true)
+
+    private def isImpl[A: Show: Resolvable: Encoder](expected: A, negate: Boolean = false): AssertStep = {
       val expectedShow = expected.show
       val baseTitle = if (jsonPath == JsonPath.root) s"$target is $expectedShow" else s"$target's field '$jsonPath' is $expectedShow"
 
@@ -117,7 +120,7 @@ object JsonSteps {
               (expectedWithoutMatchers, actualWithoutMatchers, matcherAssertions) = withMatchers
               withIgnoredFields ← handleIgnoredFields(s, expectedWithoutMatchers, actualWithoutMatchers)
               (expectedPrepared, actualPrepared) = withIgnoredFields
-            } yield GenericEqualityAssertion(expectedPrepared, actualPrepared) andAll matcherAssertions
+            } yield GenericEqualityAssertion(expectedPrepared, actualPrepared, negate) andAll matcherAssertions
         }
       )
     }

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/matchers/MatcherResolver.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/matchers/MatcherResolver.scala
@@ -36,13 +36,13 @@ case class MatcherResolver(matchers: List[Matcher] = Nil) {
     }
 
   // Removes JSON fields targetted by matchers and builds corresponding matchers assertions
-  def prepareMatchers(matchers: List[Matcher], expected: Json, actual: Json): (Json, Json, Seq[MatcherAssertion]) =
+  def prepareMatchers(matchers: List[Matcher], expected: Json, actual: Json, negate: Boolean): (Json, Json, Seq[MatcherAssertion]) =
     if (matchers.isEmpty)
       (expected, actual, Nil)
     else {
       val pathAssertions = CornichonJson.findAllJsonWithValue(matchers.map(_.fullKey), expected)
         .zip(matchers)
-        .map { case (jsonPath, matcher) ⇒ (jsonPath, MatcherAssertion.atJsonPath(jsonPath, actual, matcher)) }
+        .map { case (jsonPath, matcher) ⇒ (jsonPath, MatcherAssertion.atJsonPath(jsonPath, actual, matcher, negate)) }
 
       val jsonPathToIgnore = pathAssertions.map(_._1)
       val newExpected = CornichonJson.removeFieldsByPath(expected, jsonPathToIgnore)

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/matchers/MatcherResolver.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/matchers/MatcherResolver.scala
@@ -20,10 +20,10 @@ case class MatcherResolver(matchers: List[Matcher] = Nil) {
     MatcherParser.parse(input)
 
   def resolveMatcherKeys(mk: MatcherKey): Either[CornichonError, Matcher] =
-    allMatchersByKey(mk.key) match {
-      case Nil         ⇒ Left(MatcherUndefined(mk.key))
-      case m :: Nil    ⇒ Right(m)
-      case m :: others ⇒ Left(DuplicateMatcherDefinition(m.key, (m :: others).map(_.description)))
+    allMatchersByKey.get(mk.key) match {
+      case None              ⇒ Left(MatcherUndefined(mk.key))
+      case Some(m :: Nil)    ⇒ Right(m)
+      case Some(m :: others) ⇒ Left(DuplicateMatcherDefinition(m.key, (m :: others).map(_.description)))
     }
 
   def findAllMatchers(input: String): Either[CornichonError, List[Matcher]] =

--- a/cornichon-scalatest/src/test/scala/com/github/agourlay/cornichon/examples/superHeroes/SuperHeroesScenario.scala
+++ b/cornichon-scalatest/src/test/scala/com/github/agourlay/cornichon/examples/superHeroes/SuperHeroesScenario.scala
@@ -88,6 +88,18 @@ class SuperHeroesScenario extends CornichonFeature {
 
         Then assert body.path("name").isNot("Superman")
 
+        Then assert body.path("name").isNot("*any-integer*")
+
+        Then assert body.path("publisher").isNot(
+          """
+          {
+            "name":"Marvel",
+            "foundationYear":*any-string*,
+            "location":"Burbank, California"
+          }
+          """
+        )
+
         Then assert body.path("country").isAbsent
 
         Then assert body.path("hasSuperpowers").is(false)

--- a/cornichon-scalatest/src/test/scala/com/github/agourlay/cornichon/examples/superHeroes/SuperHeroesScenario.scala
+++ b/cornichon-scalatest/src/test/scala/com/github/agourlay/cornichon/examples/superHeroes/SuperHeroesScenario.scala
@@ -86,6 +86,8 @@ class SuperHeroesScenario extends CornichonFeature {
 
         Then assert body.path("name").matchesRegex(".*man".r)
 
+        Then assert body.path("name").isNot("Superman")
+
         Then assert body.path("country").isAbsent
 
         Then assert body.path("hasSuperpowers").is(false)


### PR DESCRIPTION
Hi,

this adds `isNot` to the `JsonStepBuilder`, like: `Then assert body.path("name").isNot("Superman")` to explicitly not expect a specific json value.

I don't know if there is something like this already present. I just wanna make a suggestion here.
The PR also needs some polishing and probably more tests.

Please let me know what you think.

Matthias