### PR TITLE
WIP: cornichon-check

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val noPublishSettings = Seq(
 lazy val cornichon =
   project
     .in(file("."))
-    .aggregate(core, scalatest, docs, benchmarks, testFramework, httpMock, kafka)
+    .aggregate(core, scalatest, docs, benchmarks, testFramework, httpMock, kafka, check)
     .settings(commonSettings)
     .settings(noPublishSettings)
     .settings(
@@ -211,6 +211,17 @@ lazy val httpMock =
         library.http4sCirce,
         library.http4sDsl
       )
+    )
+
+lazy val check =
+  project
+    .in(file("./cornichon-check"))
+    .dependsOn(core, scalatest % Test)
+    .enablePlugins(SbtScalariform)
+    .settings(commonSettings)
+    .settings(formattingSettings)
+    .settings(
+      name := "cornichon-check"
     )
 
 lazy val benchmarks =

--- a/cornichon-check/TODO.md
+++ b/cornichon-check/TODO.md
@@ -1,0 +1,6 @@
+Roadmap:
+
+- Offer to pass initial Seed to Generator to have deterministic run
+- Calls to Generators are generating log lines with the name/value to ease debugging
+- Explore interaction with ScalaCheck
+- Cleanup types definition

--- a/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/CheckDsl.scala
+++ b/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/CheckDsl.scala
@@ -1,0 +1,10 @@
+package com.github.agourlay.cornichon.check
+
+import com.github.agourlay.cornichon.core.Step
+
+trait CheckDsl {
+
+  def checkModel(model: Model): Step =
+    CheckStep(model)
+
+}

--- a/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/CheckDsl.scala
+++ b/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/CheckDsl.scala
@@ -4,7 +4,7 @@ import com.github.agourlay.cornichon.core.Step
 
 trait CheckDsl {
 
-  def checkModel(model: Model): Step =
-    CheckStep(model)
+  def check_model[A, B, C, D, E, F](maxNumberOfRuns: Int, maxNumberOfTransitions: Int)(modelRunner: ModelRunner[A, B, C, D, E, F]): Step =
+    CheckStep(maxNumberOfRuns, maxNumberOfTransitions, modelRunner)
 
 }

--- a/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/CheckEngine.scala
+++ b/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/CheckEngine.scala
@@ -1,0 +1,24 @@
+package com.github.agourlay.cornichon.check
+
+import cats.data.NonEmptyList
+import com.github.agourlay.cornichon.core.{ CornichonError, Done, RunState }
+import monix.eval.Task
+
+object CheckEngine {
+
+  def run(initialRunState: RunState, model: Model): Task[Either[NonEmptyList[CornichonError], Done]] = {
+//    model.states.map{ s =>
+//      val preCond = s.preConditions.map(_.run(initialRunState))
+//      Task.gather(preCond).flatMap{ preConditions =>
+//        preConditions.collect{case Right(e) => e}
+//        preConditions.collect{case Left(e) => e}
+//      }
+//    }
+
+    Task.delay {
+      println(s"Check engine with initialState\n$initialRunState and model $model")
+      Right(Done)
+    }
+  }
+
+}

--- a/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/CheckEngine.scala
+++ b/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/CheckEngine.scala
@@ -1,24 +1,137 @@
 package com.github.agourlay.cornichon.check
 
 import cats.data.NonEmptyList
-import com.github.agourlay.cornichon.core.{ CornichonError, Done, RunState }
+import com.github.agourlay.cornichon.core._
+import com.github.agourlay.cornichon.steps.regular.assertStep.AssertStep
 import monix.eval.Task
+import cats.syntax.either._
 
-object CheckEngine {
+import scala.util.Random
 
-  def run(initialRunState: RunState, model: Model): Task[Either[NonEmptyList[CornichonError], Done]] = {
-//    model.states.map{ s =>
-//      val preCond = s.preConditions.map(_.run(initialRunState))
-//      Task.gather(preCond).flatMap{ preConditions =>
-//        preConditions.collect{case Right(e) => e}
-//        preConditions.collect{case Left(e) => e}
-//      }
-//    }
+class CheckEngine[A, B, C, D, E, F](engine: Engine, cs: CheckStep[A, B, C, D, E, F], modelRunner: ModelRunner[A, B, C, D, E, F], maxNumberOfTransitions: Int) {
 
-    Task.delay {
-      println(s"Check engine with initialState\n$initialRunState and model $model")
-      Right(Done)
+  private val model = modelRunner.model
+  private val genA = modelRunner.generatorA
+  private val genB = modelRunner.generatorB
+  private val genC = modelRunner.generatorC
+  private val genD = modelRunner.generatorD
+  private val genE = modelRunner.generatorE
+  private val genF = modelRunner.generatorF
+
+  private val rd = Random
+
+  private def checkAssertions(initialRunState: RunState, assertions: List[AssertStep]): Task[List[Either[NonEmptyList[CornichonError], Done]]] =
+    Task.gather(assertions.map(_.run(initialRunState)))
+
+  private def returnValidTransitions(initialRunState: RunState)(transitions: List[(Double, State[A, B, C, D, E, F])]): Task[List[(Double, State[A, B, C, D, E, F], Boolean)]] =
+    Task.gather {
+      transitions.map { t ⇒
+        checkAssertions(initialRunState, t._2.preConditions).map { preConditionsRes ⇒
+          val failedConditions = preConditionsRes.collect { case Left(e) ⇒ e.toList }.flatten
+          (t._1, t._2, failedConditions.isEmpty)
+        }
+      }
+    }
+
+  def run(initialRunState: RunState): Task[(RunState, FailedStep Either SuccessEndOfRun)] =
+    //check precondition for starting state
+    checkAssertions(initialRunState, model.startingState.preConditions).flatMap { startingIsValid ⇒
+      startingIsValid.collect { case Left(e) ⇒ e }.flatMap(_.toList) match {
+        case firstFailure :: others ⇒
+          val errors = NonEmptyList.of(firstFailure, others: _*)
+          Task.now((initialRunState, FailedStep(cs, errors).asLeft))
+        case Nil ⇒
+          // run first state
+          loopRun(initialRunState, model.startingState, 0)
+      }
+    }
+
+  private def loopRun(initialRunState: RunState, state: State[A, B, C, D, E, F], currentNumberOfTransitions: Int): Task[(RunState, FailedStep Either SuccessEndOfRun)] =
+    if (currentNumberOfTransitions > maxNumberOfTransitions)
+      Task.delay((initialRunState, MaxTransitionReached(maxNumberOfTransitions).asRight))
+    else {
+      runStateActionAndValidatePostConditions(initialRunState, state).flatMap {
+        case (newState, res) ⇒
+          res.fold(
+            fs ⇒ Task.delay((newState, fs.asLeft)),
+            _ ⇒ {
+              // check available outgoing transitions
+              model.transitions.get(state) match {
+                case None ⇒
+                  // No transitions defined -> end of run
+                  Task.delay((newState, EndStateReached(state.description, currentNumberOfTransitions).asRight))
+                case Some(transitions) ⇒
+                  returnValidTransitions(newState)(transitions).flatMap { possibleNextStates ⇒
+                    val (validNext, _) = possibleNextStates.partition(_._3)
+                    if (validNext.isEmpty)
+                      Task.delay((newState, FailedStep(cs, NonEmptyList.one(NoValidTransitionAvailableForState(state.description))).asLeft))
+                    else {
+                      // pick one transition according to the weight
+                      val nextState = pickTransitionAccordingToProbability(rd, validNext)
+                      loopRun(newState, nextState, currentNumberOfTransitions + 1)
+                    }
+                  }
+              }
+            }
+          )
+      }
+    }
+
+  // Assumes valid pre-conditions
+  private def runStateActionAndValidatePostConditions(initialRunState: RunState, state: State[A, B, C, D, E, F]): Task[(RunState, FailedStep Either Done)] = {
+    val s = initialRunState.session
+    // run action
+    state.action(genA.value(s), genB.value(s), genC.value(s), genD.value(s), genE.value(s), genF.value(s))
+      .run(engine)(initialRunState)
+      .flatMap {
+        case (newState, res) ⇒
+          res.fold(
+            fs ⇒ Task.delay((newState, res)),
+            _ ⇒ {
+              // check post-conditions
+              checkAssertions(newState, state.postConditions)
+                .flatMap { afterConditionIsValid ⇒
+                  val failures = afterConditionIsValid.collect { case Left(e) ⇒ e }.flatMap(_.toList)
+                  failures match {
+                    case firstFailure :: others ⇒
+                      val errors = NonEmptyList.of(firstFailure, others: _*)
+                      Task.now((initialRunState, FailedStep(cs, errors).asLeft))
+                    case Nil ⇒
+                      // run first state
+                      Task.delay((newState, res))
+                  }
+                }
+            }
+          )
+      }
+  }
+
+  //https://stackoverflow.com/questions/9330394/how-to-pick-an-item-by-its-probability
+  private def pickTransitionAccordingToProbability(rd: Random, inputs: List[(Double, State[A, B, C, D, E, F], Boolean)]): State[A, B, C, D, E, F] = {
+    val weight = rd.nextDouble()
+    var cumulativeProbability = 0.0
+
+    var selectedState: Option[State[A, B, C, D, E, F]] = None
+
+    for (state ← inputs) {
+      cumulativeProbability += state._1
+      if (weight <= cumulativeProbability && selectedState.isEmpty)
+        selectedState = Some(state._2)
+    }
+
+    selectedState.getOrElse {
+      rd.shuffle(inputs).head._2
     }
   }
 
 }
+
+case class NoValidTransitionAvailableForState(state: String) extends CornichonError {
+  def baseErrorMessage: String = s"No outgoing transition found to a state with valid pre-conditions from $state"
+}
+
+sealed trait SuccessEndOfRun
+
+case class EndStateReached(state: String, numberOfTransitions: Int) extends SuccessEndOfRun
+
+case class MaxTransitionReached(numberOfTransitions: Int) extends SuccessEndOfRun

--- a/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/CheckStep.scala
+++ b/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/CheckStep.scala
@@ -1,0 +1,25 @@
+package com.github.agourlay.cornichon.check
+
+import cats.data.NonEmptyList
+import com.github.agourlay.cornichon.core.Engine.{ errorsToFailureStep, successLog }
+import com.github.agourlay.cornichon.core._
+import monix.eval.Task
+
+import scala.concurrent.duration.Duration
+
+case class CheckStep(model: Model) extends ValueStep[Done] {
+
+  val title = s"Checking model $model"
+
+  def setTitle(newTitle: String) = this
+
+  def run(initialRunState: RunState): Task[Either[NonEmptyList[CornichonError], Done]] =
+    CheckEngine.run(initialRunState, model)
+
+  def onError(errors: NonEmptyList[CornichonError], initialRunState: RunState): (Vector[LogInstruction], FailedStep) =
+    errorsToFailureStep(this, initialRunState.depth, errors)
+
+  def onSuccess(result: Done, initialRunState: RunState, executionTime: Duration): (Option[LogInstruction], Option[Session]) =
+    (successLog(title, initialRunState.depth, true, executionTime), None)
+
+}

--- a/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/CheckStep.scala
+++ b/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/CheckStep.scala
@@ -1,25 +1,116 @@
 package com.github.agourlay.cornichon.check
 
-import cats.data.NonEmptyList
-import com.github.agourlay.cornichon.core.Engine.{ errorsToFailureStep, successLog }
+import cats.data.Validated.Invalid
+import cats.data.{ NonEmptyList, ValidatedNel }
+import cats.syntax.option._
+import cats.syntax.either._
+import cats.syntax.validated._
+import cats.syntax.apply._
+import com.github.agourlay.cornichon.core.Done.rightDone
 import com.github.agourlay.cornichon.core._
 import monix.eval.Task
+import com.github.agourlay.cornichon.util.Timing._
 
-import scala.concurrent.duration.Duration
+case class CheckStep[A, B, C, D, E, F](maxNumberOfRuns: Int, maxNumberOfTransitions: Int, modelRunner: ModelRunner[A, B, C, D, E, F]) extends WrapperStep {
 
-case class CheckStep(model: Model) extends ValueStep[Done] {
+  val model = modelRunner.model
+  val title = s"Checking model '${model.description}' with maxNumberOfRuns=$maxNumberOfRuns amd maxNumberOfTransitions=$maxNumberOfTransitions"
 
-  val title = s"Checking model $model"
+  private def repeatSuccessModel(runNumber: Int)(engine: Engine, initialRunState: RunState): Task[(RunState, Either[FailedStep, Done])] =
+    if (runNumber > maxNumberOfRuns)
+      Task.now((initialRunState, rightDone))
+    else {
+      val checkEngine = new CheckEngine(engine, this, modelRunner, maxNumberOfTransitions)
+      checkEngine.run(initialRunState).flatMap {
+        case (newState, res) ⇒
+          res match {
+            case Left(fs) ⇒
+              Task.now((newState, fs.asLeft))
+            case Right(endOfRun) ⇒
+              // success case we are propagating the logs but the not Session itself
+              val nextRunState = newState.withSession(initialRunState.session)
+              val runLog = buildInfoRunLog(runNumber, endOfRun, initialRunState.depth)
+              repeatSuccessModel(runNumber + 1)(engine, nextRunState.appendLog(runLog))
+          }
+      }
+    }
 
-  def setTitle(newTitle: String) = this
+  private def buildInfoRunLog(runNumber: Int, endOfRun: SuccessEndOfRun, depth: Int): LogInstruction = {
+    val reason = endOfRun match {
+      case EndStateReached(state, numberOfTransitions) ⇒ s"End state reached on state $state after $numberOfTransitions transitions"
+      case MaxTransitionReached(_)                     ⇒ "Max transitions number per run reached"
+    }
+    InfoLogInstruction(s"Run #$runNumber - $reason", depth)
+  }
 
-  def run(initialRunState: RunState): Task[Either[NonEmptyList[CornichonError], Done]] =
-    CheckEngine.run(initialRunState, model)
+  private def validateTransitions(transitions: Map[State[A, B, C, D, E, F], List[(Double, State[A, B, C, D, E, F])]]): ValidatedNel[CornichonError, Done] = {
+    val emptyTransitionForState: ValidatedNel[CornichonError, Done] = transitions.find(_._2.isEmpty)
+      .map(s ⇒ EmptyTransitionsDefinitionForState(s._1.description)).toInvalidNel(Done)
 
-  def onError(errors: NonEmptyList[CornichonError], initialRunState: RunState): (Vector[LogInstruction], FailedStep) =
-    errorsToFailureStep(this, initialRunState.depth, errors)
+    val noTransitionsForStart: ValidatedNel[CornichonError, Done] = if (transitions.get(model.startingState).isEmpty)
+      NoTransitionsDefinitionForStartingState(model.startingState.description).invalidNel
+    else Done.validDone
 
-  def onSuccess(result: Done, initialRunState: RunState, executionTime: Duration): (Option[LogInstruction], Option[Session]) =
-    (successLog(title, initialRunState.depth, true, executionTime), None)
+    val duplicateEntries: ValidatedNel[CornichonError, Done] = transitions.find { e ⇒
+      val allStates = e._2.map(_._2)
+      allStates.distinct.size != allStates.size
+    }.map(_._1.description).map(DuplicateTransitionsDefinitionForState).toInvalidNel(Done)
 
+    val sumOfWeightIsCorrect: ValidatedNel[CornichonError, Done] = transitions.find { e ⇒
+      e._2.map(_._1).sum != 1.0d
+    }.map(_._1.description).map(IncorrectTransitionsWeightDefinitionForState).toInvalidNel(Done)
+
+    emptyTransitionForState *> noTransitionsForStart *> duplicateEntries *> sumOfWeightIsCorrect
+  }
+
+  override def run(engine: Engine)(initialRunState: RunState): Task[(RunState, FailedStep Either Done)] =
+    withDuration {
+      validateTransitions(model.transitions) match {
+        case Invalid(ce) ⇒
+          Task.delay((initialRunState, FailedStep(this, ce).asLeft))
+        case _ ⇒
+          repeatSuccessModel(1)(engine: Engine, initialRunState.nestedContext)
+      }
+    }.map {
+      case (run, executionTime) ⇒
+        val (checkState, report) = run
+        val depth = initialRunState.depth
+        val (fullLogs, xor) = report.fold(
+          failedStep ⇒ {
+            val fullLogs = failedTitleLog(depth) +: checkState.logs :+ FailureLogInstruction(s"Check model block failed ", depth, Some(executionTime))
+            val artificialFailedStep = FailedStep.fromSingle(failedStep.step, CheckBlockContainFailedSteps(failedStep.errors))
+            (fullLogs, Left(artificialFailedStep))
+          },
+          _ ⇒ {
+            val fullLogs = successTitleLog(depth) +: checkState.logs :+ SuccessLogInstruction(s"Check block succeeded", depth, Some(executionTime))
+            (fullLogs, rightDone)
+          }
+        )
+        (initialRunState.mergeNested(checkState, fullLogs), xor)
+    }
+}
+
+case class EmptyTransitionsDefinitionForState(stateDescription: String) extends CornichonError {
+  def baseErrorMessage: String = s"Empty outgoing transitions definition found '$stateDescription'"
+}
+
+case class DuplicateTransitionsDefinitionForState(stateDescription: String) extends CornichonError {
+  def baseErrorMessage: String = s"Transitions definition from '$stateDescription' contains duplicates target state"
+}
+
+case class IncorrectTransitionsWeightDefinitionForState(stateDescription: String) extends CornichonError {
+  def baseErrorMessage: String = s"Transitions definition from '$stateDescription' contains incorrect weight definition (above 1.0)"
+}
+
+case class NoTransitionsDefinitionForStartingState(stateDescription: String) extends CornichonError {
+  def baseErrorMessage: String = s"No outgoing transitions definition found for starting state $stateDescription"
+}
+
+case class InvalidTransitionDefinitionForState(stateDescription: String) extends CornichonError {
+  def baseErrorMessage: String = s"Invalid transition definition for state '$stateDescription'"
+}
+
+case class CheckBlockContainFailedSteps(errors: NonEmptyList[CornichonError]) extends CornichonError {
+  val baseErrorMessage = s"Check block failed"
+  override val causedBy = errors.toList
 }

--- a/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/Generator.scala
+++ b/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/Generator.scala
@@ -1,0 +1,24 @@
+package com.github.agourlay.cornichon.check
+
+import com.github.agourlay.cornichon.core.Session
+
+trait Generator[A] {
+  def value(session: Session): () ⇒ A
+  // FIXME: don't use context bound for now as it would make the type definition crazy in the engine
+  def show(a: A): String = a.toString
+}
+
+case object NoValue
+
+case object NoValueGenerator extends Generator[NoValue.type] {
+  def value(session: Session) = () ⇒ NoValue
+
+}
+
+case class ValueGenerator[A](genFct: () ⇒ A) extends Generator[A] {
+  override def value(session: Session) = genFct
+}
+
+case class ValueFromSessionGenerator[A](genFct: Session ⇒ A) extends Generator[A] {
+  override def value(session: Session) = () ⇒ genFct(session)
+}

--- a/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/State.scala
+++ b/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/State.scala
@@ -1,0 +1,14 @@
+package com.github.agourlay.cornichon.check
+
+import com.github.agourlay.cornichon.steps.regular.EffectStep
+import com.github.agourlay.cornichon.steps.regular.assertStep.AssertStep
+
+case class Model(states: List[State])
+
+case class State(
+    preConditions: List[AssertStep],
+    action: EffectStep,
+    postConditions: List[AssertStep],
+    transitions: List[Transition])
+
+case class Transition(weight: Double, state: State)

--- a/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/State.scala
+++ b/cornichon-check/src/main/scala/com/github/agourlay/cornichon/check/State.scala
@@ -1,14 +1,37 @@
 package com.github.agourlay.cornichon.check
 
-import com.github.agourlay.cornichon.steps.regular.EffectStep
+import com.github.agourlay.cornichon.core.Step
 import com.github.agourlay.cornichon.steps.regular.assertStep.AssertStep
 
-case class Model(states: List[State])
+case class Model[A, B, C, D, E, F](
+    description: String,
+    startingState: State[A, B, C, D, E, F],
+    transitions: Map[State[A, B, C, D, E, F], List[(Double, State[A, B, C, D, E, F])]])
 
-case class State(
+case class State[A, B, C, D, E, F](
+    description: String,
     preConditions: List[AssertStep],
-    action: EffectStep,
-    postConditions: List[AssertStep],
-    transitions: List[Transition])
+    action: (() ⇒ A, () ⇒ B, () ⇒ C, () ⇒ D, () ⇒ E, () ⇒ F) ⇒ Step,
+    postConditions: List[AssertStep])
 
-case class Transition(weight: Double, state: State)
+case class ModelRunner[A, B, C, D, E, F](
+    generatorA: Generator[A],
+    generatorB: Generator[B],
+    generatorC: Generator[C],
+    generatorD: Generator[D],
+    generatorE: Generator[E],
+    generatorF: Generator[F],
+    model: Model[A, B, C, D, E, F])
+
+object ModelRunner {
+
+  def make[A](genA: Generator[A])(model: Model[A, NoValue.type, NoValue.type, NoValue.type, NoValue.type, NoValue.type]): ModelRunner[A, NoValue.type, NoValue.type, NoValue.type, NoValue.type, NoValue.type] =
+    ModelRunner(genA, NoValueGenerator, NoValueGenerator, NoValueGenerator, NoValueGenerator, NoValueGenerator, model)
+
+  def make[A, B](genA: Generator[A], genB: Generator[B])(model: Model[A, B, NoValue.type, NoValue.type, NoValue.type, NoValue.type]) =
+    ModelRunner(genA, genB, NoValueGenerator, NoValueGenerator, NoValueGenerator, NoValueGenerator, model)
+
+  def make[A, B, C](genA: Generator[A], genB: Generator[B], genC: Generator[C])(model: Model[A, B, C, NoValue.type, NoValue.type, NoValue.type]) =
+    ModelRunner(genA, genB, genC, NoValueGenerator, NoValueGenerator, NoValueGenerator, model)
+
+}

--- a/cornichon-check/src/test/scala/com/github/agourlay/cornichon/check/CheckStepSpec.scala
+++ b/cornichon-check/src/test/scala/com/github/agourlay/cornichon/check/CheckStepSpec.scala
@@ -1,0 +1,5 @@
+package com.github.agourlay.cornichon.check
+
+class CheckEngineSpec {
+
+}

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Session.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Session.scala
@@ -45,6 +45,13 @@ case class Session(content: Map[String, Vector[String]]) extends AnyVal {
   def getHistory(key: String): Either[KeyNotFoundInSession, Vector[String]] =
     content.get(key).toRight(KeyNotFoundInSession(key, this))
 
+  def getPrevious(key: String): Either[CornichonError, Option[String]] =
+    for {
+      values ← content.get(key).toRight(KeyNotFoundInSession(key, this))
+      indice = values.size - 2
+      value ← values.lift(indice).asRight
+    } yield value
+
   def addValue(key: String, value: String): Either[CornichonError, Session] = {
 
     def validateKey(key: String): Either[CornichonError, String] = {

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/resolver/Mapper.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/resolver/Mapper.scala
@@ -1,5 +1,7 @@
 package com.github.agourlay.cornichon.resolver
 
+import com.github.agourlay.cornichon.core.Session
+
 sealed trait Mapper
 
 case class SimpleMapper(generator: () ⇒ String) extends Mapper
@@ -8,6 +10,10 @@ object SimpleMapper {
   implicit def fromFct(generator: () ⇒ String): SimpleMapper = SimpleMapper(generator)
 }
 
+case class SessionMapper(generator: Session ⇒ String) extends Mapper
+
 case class TextMapper(key: String, transform: String ⇒ String = identity) extends Mapper
+
+case class HistoryMapper(key: String, transform: Vector[String] ⇒ String) extends Mapper
 
 case class JsonMapper(key: String, jsonPath: String, transform: String ⇒ String = identity) extends Mapper


### PR DESCRIPTION
Work in progress implementation of a property based testing module.

Initial inspiration comes from https://functional.works-hub.com/learn/property-based-integration-testing-using-haskell-6c25c

Remaining points of work

- [ ] Offer to pass initial Seed to Generator to have deterministic runs

- [ ] Calls to Generators are creating log lines with the name/value to ease debugging

- [ ] Explore integration with ScalaCheck (shrinking?)

- [ ] Cleanup types definition