### PR TITLE
eventuallyStep logs all distinct errors

### DIFF
--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/LogInstruction.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/LogInstruction.scala
@@ -26,10 +26,17 @@ sealed trait LogInstruction {
 
 object LogInstruction {
   val physicalMargin: StringOps = "   "
-  def renderLogs(logs: Seq[LogInstruction]): String = {
-    // Logs can potentially be long
-    val acc = logs.foldLeft(StringBuilder.newBuilder)((acc, l) ⇒ acc.append("\n").append(l.colorized))
-    acc.append("\n").result()
+  def renderLogs(logs: Seq[LogInstruction], colorized: Boolean = true): String = {
+    // Logs can potentially be really long - enable imperative mode
+    val b = StringBuilder.newBuilder
+    var i = 0
+    val logNb = logs.size
+    while (i < logNb) {
+      val l = logs(i)
+      b.append("\n").append(if (colorized) l.colorized else l.completeMessage)
+      i += 1
+    }
+    b.append("\n").result()
   }
 
   def printLogs(logs: Seq[LogInstruction]): Unit =

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/package.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/package.scala
@@ -1,6 +1,5 @@
 package com.github.agourlay.cornichon.core
 
-import cats.data.NonEmptyList
 import monix.eval.Task
 
 package object core {


### PR DESCRIPTION
This PR makes sure all distinct errors encountered during an `Eventually` run are logged properly.

The final error message remains unchanged by only mentioning the last error but the actual run log will provide all the details to hunt down the intermediary failures.

@cneijenhuis I hope this should be enough to prevent `people` from wasting hours chasing errors.