### PR TITLE
kafka DSL creates one consumer/producer pair per feature

### DIFF
--- a/cornichon-docs/src/main/tut/modules/module-kafka.md
+++ b/cornichon-docs/src/main/tut/modules/module-kafka.md
@@ -7,10 +7,9 @@ title:  "Kafka integration"
 
 `cornichon-kafka` offers a support for [Kafka](https://kafka.apache.org) v2.0.0
 
-Due to the architecture of kafka and the handling of consumers offsets, **the default execution of
-scenarios and features is sequential**.
+The kafka client is shared at the feature level by all the scenarios and is configured with a fixed group-id to 'cornichon-groupId' and is set with offset-reset to 'earliest'.
 
-The underlying kafka client used in cornichon is configured with a fixed group-id to 'cornichon' and is set with offset-reset to 'earliest'.
+Due to the architecture of kafka and the handling of consumers offsets, **the default execution of scenarios is sequential**.
 
 - Comprehensive example
 
@@ -19,6 +18,9 @@ import com.github.agourlay.cornichon.CornichonFeature
 import com.github.agourlay.cornichon.kafka.KafkaDsl
 
 class KafkaExample extends CornichonFeature with KafkaDsl {
+
+  override lazy val kafkaBootstrapServersHost: String = "localhost"
+  override lazy val kafkaBootstrapServersPort: Int = 9092
 
   def feature = Feature("Kafka DSL") {
 
@@ -39,32 +41,27 @@ class KafkaExample extends CornichonFeature with KafkaDsl {
       Then assert kafka("cornichon").key_is("success")
       Then assert kafka("cornichon").message_value.is("I am a plain string")
     }
+    
     Scenario("Can use cornichon jsonAssertions on the message value") {
       Given I put_topic(
         topic = "cornichon",
         key = "json",
-        message =
-          """{
-            | "coffee"   : "black",
-            | "cornichon": "green"
-            |}""".stripMargin
+        message = """{ "coffee": "black", "cornichon": "green"}"""
       )
 
-      When I read_from_topic(
-        topic = "cornichon"
-      )
-
-      Then assert kafka("cornichon").message_value.ignoring("coffee").is(
-        """{
-          | "cornichon": "green"
-          |}""".stripMargin)
+      When I read_from_topic("cornichon")
+      Then assert kafka("cornichon").topic_is("json")
+      Then assert kafka("cornichon").message_value.ignoring("coffee").is("""
+        {
+          "cornichon": "green"
+        }
+        """
+       )
     }
 
   }
 }
-
-
 ```
 
 Note that this dsl always return the latest `amount` of messages found on the topic.
-The consumer polls `timeout` ms until it does not find any new messages anymore
+The consumer polls `timeoutMs` until it does not find any new messages anymore

--- a/cornichon-docs/src/main/tut/modules/module-kafka.md
+++ b/cornichon-docs/src/main/tut/modules/module-kafka.md
@@ -31,7 +31,7 @@ class KafkaExample extends CornichonFeature with KafkaDsl {
 
       When I read_from_topic(
         topic = "cornichon",
-        timeout = 500,
+        timeoutMs = 500,
         amount = 1
       )
 

--- a/cornichon-kafka/src/main/scala/com/github/agourlay/cornichon/kafka/KafkaDsl.scala
+++ b/cornichon-kafka/src/main/scala/com/github/agourlay/cornichon/kafka/KafkaDsl.scala
@@ -22,8 +22,8 @@ trait KafkaDsl {
   // Kafka scenario can not run in // because they share the same producer/consumer
   override lazy val executeScenariosInParallel: Boolean = false
 
-  val kafkaBootstrapServersHost: String = "localhost"
-  val kafkaBootstrapServersPort: Int = 9092
+  lazy val kafkaBootstrapServersHost: String = "localhost"
+  lazy val kafkaBootstrapServersPort: Int = 9092
   private lazy val kafkaBootstrapServer = s"$kafkaBootstrapServersHost:$kafkaBootstrapServersPort"
 
   val kafkaProducerConfig: KafkaProducerConfig = KafkaProducerConfig()

--- a/cornichon-kafka/src/main/scala/com/github/agourlay/cornichon/kafka/KafkaDsl.scala
+++ b/cornichon-kafka/src/main/scala/com/github/agourlay/cornichon/kafka/KafkaDsl.scala
@@ -10,8 +10,6 @@ import org.apache.kafka.clients.producer._
 import org.apache.kafka.common.serialization.{ StringDeserializer, StringSerializer }
 import com.github.agourlay.cornichon.kafka.KafkaDsl._
 import org.apache.kafka.clients.consumer.{ ConsumerConfig, ConsumerRecord, KafkaConsumer }
-import pureconfig.generic.ProductHint
-import pureconfig.{ CamelCase, ConfigFieldMapping }
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
@@ -20,15 +18,24 @@ import scala.concurrent.{ Future, Promise }
 trait KafkaDsl {
   this: BaseFeature with CoreDsl ⇒
 
-  // Kafka tests can not run in //
+  // Kafka scenario can not run in // because they share the same producer/consumer
   override lazy val executeScenariosInParallel: Boolean = false
 
-  def put_topic(topic: String, key: String, message: String) = EffectStep.fromAsync(
+  val kafkaBootstrapServersHost: String = "localhost"
+  val kafkaBootstrapServersPort: Int = 9092
+
+  val kafkaProducerConfig: KafkaProducerConfig = KafkaProducerConfig()
+  val kafkaConsumerConfig: KafkaConsumerConfig = KafkaConsumerConfig()
+
+  lazy val featureProducer = producer(s"$kafkaBootstrapServersHost:$kafkaBootstrapServersPort", kafkaProducerConfig)
+  lazy val featureConsumer = consumer(s"$kafkaBootstrapServersHost:$kafkaBootstrapServersPort", kafkaConsumerConfig)
+
+  def put_topic(topic: String, key: String, message: String): EffectStep = EffectStep.fromAsync(
     title = s"put message=$message with key=$key to topic=$topic",
     effect = s ⇒ {
-      val pr = buildProducerRecord(topic, key, message)
+      val pr = new ProducerRecord[String, String](topic, key, message)
       val p = Promise[Unit]()
-      producer.send(pr, new Callback {
+      featureProducer.send(pr, new Callback {
         def onCompletion(metadata: RecordMetadata, exception: Exception): Unit =
           if (exception == null)
             p.success(())
@@ -39,21 +46,20 @@ trait KafkaDsl {
     }
   )
 
-  def read_from_topic(topic: String, amount: Int = 1, timeout: Int = 500) = EffectStep.fromAsync(
+  def read_from_topic(topic: String, amount: Int = 1, timeout: Int = 500): EffectStep = EffectStep.fromAsync(
     title = s"reading the last $amount messages from topic=$topic",
     effect = s ⇒ Future {
-      consumer.unsubscribe()
-      consumer.subscribe(Seq(topic).asJava)
+      featureConsumer.subscribe(Seq(topic).asJava)
       val messages = ListBuffer.empty[ConsumerRecord[String, String]]
       var nothingNewAnymore = false
       val pollDuration = Duration.ofMillis(timeout.toLong)
       while (!nothingNewAnymore) {
-        val newMessages = consumer.poll(pollDuration)
+        val newMessages = featureConsumer.poll(pollDuration)
         val collectionOfNewMessages = newMessages.iterator().asScala.toList
         messages ++= collectionOfNewMessages
         nothingNewAnymore = newMessages.isEmpty
       }
-      consumer.commitSync()
+      featureConsumer.commitSync()
       messages.drop(messages.size - amount)
       messages.foldLeft(s) { (session, value) ⇒
         commonSessionExtraction(session, topic, value).valueUnsafe
@@ -78,16 +84,12 @@ trait KafkaDsl {
 
 object KafkaDsl {
   import scala.concurrent.ExecutionContext.Implicits.global
-  import pureconfig.generic.auto._
 
-  // if the config does not exist we use the default values
-  lazy val kafkaConfig = pureconfig.loadConfigOrThrow[Option[KafkaConfig]]("kafka").getOrElse(KafkaConfig())
-
-  lazy val producer = {
+  def producer(bootstrapServer: String, producerConfig: KafkaProducerConfig): KafkaProducer[String, String] = {
     val configMap = scala.collection.mutable.Map[String, AnyRef](
-      ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> kafkaConfig.bootstrapServers,
-      ProducerConfig.ACKS_CONFIG -> kafkaConfig.producer.ack,
-      ProducerConfig.BATCH_SIZE_CONFIG -> kafkaConfig.producer.batchSizeInBytes.toString
+      ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServer,
+      ProducerConfig.ACKS_CONFIG -> producerConfig.ack,
+      ProducerConfig.BATCH_SIZE_CONFIG -> producerConfig.batchSizeInBytes.toString
     )
 
     val p = new KafkaProducer[String, String](configMap.asJava, new StringSerializer, new StringSerializer)
@@ -97,14 +99,14 @@ object KafkaDsl {
     p
   }
 
-  lazy val consumer = {
+  def consumer(bootstrapServer: String, consumerConfig: KafkaConsumerConfig): KafkaConsumer[String, String] = {
     val configMap = scala.collection.mutable.Map[String, AnyRef](
-      ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> kafkaConfig.bootstrapServers,
+      ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServer,
       ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG -> "false",
-      ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG -> "100",
-      ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG -> "10000",
+      ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG -> consumerConfig.heartbeatIntervalMsConfig.toString,
+      ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG -> consumerConfig.sessionTimeoutMsConfig.toString,
       ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> "earliest",
-      ConsumerConfig.GROUP_ID_CONFIG -> kafkaConfig.consumer.groupId
+      ConsumerConfig.GROUP_ID_CONFIG -> consumerConfig.groupId
     )
 
     val c = new KafkaConsumer[String, String](configMap.asJava, new StringDeserializer, new StringDeserializer)
@@ -113,29 +115,14 @@ object KafkaDsl {
     })
     c
   }
-
-  def buildProducerRecord(topic: String, key: String, message: String): ProducerRecord[String, String] =
-    new ProducerRecord[String, String](topic, key, message)
-
-  def buildConsumerRecordJsonProjection(f: String ⇒ String)(record: ConsumerRecord[String, String]): String =
-    s"""{
-       |  "key": "${record.key()}",
-       |  "topic": "${record.topic()}",
-       |  "timestamp": "${record.timestamp()}",
-       |  "value": ${f(record.value())}
-       |}""".stripMargin
-
 }
 
-case class KafkaConfig(
-    bootstrapServers: String = "localhost:9092",
-    producer: KafkaProducerConfig = KafkaProducerConfig(),
-    consumer: KafkaConsumerConfig = KafkaConsumerConfig())
+case class KafkaProducerConfig(
+    ack: String = "all",
+    batchSizeInBytes: Int = 1,
+    retriesConfig: Option[Int] = None)
 
-object KafkaConfig {
-  implicit val hint = ProductHint[KafkaConfig](allowUnknownKeys = false, fieldMapping = ConfigFieldMapping(CamelCase, CamelCase))
-}
-
-case class KafkaProducerConfig(ack: String = "all", batchSizeInBytes: Int = 1, retriesConfig: Option[Int] = None)
-
-case class KafkaConsumerConfig(groupId: String = s"cornichon-groupId")
+case class KafkaConsumerConfig(
+    groupId: String = s"cornichon-groupId",
+    sessionTimeoutMsConfig: Int = 10000,
+    heartbeatIntervalMsConfig: Int = 100)

--- a/cornichon-kafka/src/main/scala/com/github/agourlay/cornichon/kafka/KafkaDsl.scala
+++ b/cornichon-kafka/src/main/scala/com/github/agourlay/cornichon/kafka/KafkaDsl.scala
@@ -2,18 +2,19 @@ package com.github.agourlay.cornichon.kafka
 
 import java.time.Duration
 
-import com.github.agourlay.cornichon.core.Session
+import com.github.agourlay.cornichon.core.{ Session, Step }
 import com.github.agourlay.cornichon.dsl.CoreDsl
 import com.github.agourlay.cornichon.feature.BaseFeature
-import com.github.agourlay.cornichon.steps.regular.EffectStep
+import com.github.agourlay.cornichon.steps.cats.EffectStep
 import org.apache.kafka.clients.producer._
 import org.apache.kafka.common.serialization.{ StringDeserializer, StringSerializer }
-import com.github.agourlay.cornichon.kafka.KafkaDsl._
+import monix.eval.Task
+import monix.execution.CancelablePromise
 import org.apache.kafka.clients.consumer.{ ConsumerConfig, ConsumerRecord, KafkaConsumer }
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.Future
 
 trait KafkaDsl {
   this: BaseFeature with CoreDsl ⇒
@@ -23,41 +24,43 @@ trait KafkaDsl {
 
   val kafkaBootstrapServersHost: String = "localhost"
   val kafkaBootstrapServersPort: Int = 9092
+  private lazy val kafkaBootstrapServer = s"$kafkaBootstrapServersHost:$kafkaBootstrapServersPort"
 
   val kafkaProducerConfig: KafkaProducerConfig = KafkaProducerConfig()
   val kafkaConsumerConfig: KafkaConsumerConfig = KafkaConsumerConfig()
 
-  lazy val featureProducer = producer(s"$kafkaBootstrapServersHost:$kafkaBootstrapServersPort", kafkaProducerConfig)
-  lazy val featureConsumer = consumer(s"$kafkaBootstrapServersHost:$kafkaBootstrapServersPort", kafkaConsumerConfig)
+  lazy val featureProducer: KafkaProducer[String, String] = producer(kafkaBootstrapServer, kafkaProducerConfig)
+  lazy val featureConsumer: KafkaConsumer[String, String] = consumer(kafkaBootstrapServer, kafkaConsumerConfig)
 
-  def put_topic(topic: String, key: String, message: String): EffectStep = EffectStep.fromAsync(
+  def put_topic(topic: String, key: String, message: String): Step = EffectStep.fromAsync(
     title = s"put message=$message with key=$key to topic=$topic",
     effect = s ⇒ {
       val pr = new ProducerRecord[String, String](topic, key, message)
-      val p = Promise[Unit]()
+      val cp = CancelablePromise[Unit]()
       featureProducer.send(pr, new Callback {
         def onCompletion(metadata: RecordMetadata, exception: Exception): Unit =
           if (exception == null)
-            p.success(())
+            cp.success(())
           else
-            p.failure(exception)
+            cp.failure(exception)
       })
-      p.future.map(_ ⇒ s)
+      Task.fromCancelablePromise(cp).map(_ ⇒ s)
     }
   )
 
-  def read_from_topic(topic: String, amount: Int = 1, timeout: Int = 500): EffectStep = EffectStep.fromAsync(
+  def read_from_topic(topic: String, amount: Int = 1, timeoutMs: Int = 500): Step = EffectStep.fromAsync(
     title = s"reading the last $amount messages from topic=$topic",
-    effect = s ⇒ Future {
+    effect = s ⇒ Task.delay {
       featureConsumer.subscribe(Seq(topic).asJava)
       val messages = ListBuffer.empty[ConsumerRecord[String, String]]
       var nothingNewAnymore = false
-      val pollDuration = Duration.ofMillis(timeout.toLong)
+      val pollDuration = Duration.ofMillis(timeoutMs.toLong)
       while (!nothingNewAnymore) {
         val newMessages = featureConsumer.poll(pollDuration)
-        val collectionOfNewMessages = newMessages.iterator().asScala.toList
-        messages ++= collectionOfNewMessages
-        nothingNewAnymore = newMessages.isEmpty
+        if (newMessages.isEmpty)
+          nothingNewAnymore = true
+        else
+          messages ++= newMessages.iterator().asScala.toList
       }
       featureConsumer.commitSync()
       messages.drop(messages.size - amount)
@@ -80,12 +83,8 @@ trait KafkaDsl {
       s"$topic-value" → response.value()
     )
 
-}
-
-object KafkaDsl {
-  import scala.concurrent.ExecutionContext.Implicits.global
-
-  def producer(bootstrapServer: String, producerConfig: KafkaProducerConfig): KafkaProducer[String, String] = {
+  // the producer is stopped after all features
+  private def producer(bootstrapServer: String, producerConfig: KafkaProducerConfig): KafkaProducer[String, String] = {
     val configMap = scala.collection.mutable.Map[String, AnyRef](
       ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServer,
       ProducerConfig.ACKS_CONFIG -> producerConfig.ack,
@@ -99,7 +98,8 @@ object KafkaDsl {
     p
   }
 
-  def consumer(bootstrapServer: String, consumerConfig: KafkaConsumerConfig): KafkaConsumer[String, String] = {
+  // the consumer is stopped after all features
+  private def consumer(bootstrapServer: String, consumerConfig: KafkaConsumerConfig): KafkaConsumer[String, String] = {
     val configMap = scala.collection.mutable.Map[String, AnyRef](
       ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServer,
       ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG -> "false",
@@ -117,12 +117,6 @@ object KafkaDsl {
   }
 }
 
-case class KafkaProducerConfig(
-    ack: String = "all",
-    batchSizeInBytes: Int = 1,
-    retriesConfig: Option[Int] = None)
+case class KafkaProducerConfig(ack: String = "all", batchSizeInBytes: Int = 1, retriesConfig: Option[Int] = None)
 
-case class KafkaConsumerConfig(
-    groupId: String = s"cornichon-groupId",
-    sessionTimeoutMsConfig: Int = 10000,
-    heartbeatIntervalMsConfig: Int = 100)
+case class KafkaConsumerConfig(groupId: String = "cornichon-groupId", sessionTimeoutMsConfig: Int = 10000, heartbeatIntervalMsConfig: Int = 100)

--- a/cornichon-kafka/src/test/scala/com/github/agourlay/kafka/kafka/KafkaExample.scala
+++ b/cornichon-kafka/src/test/scala/com/github/agourlay/kafka/kafka/KafkaExample.scala
@@ -18,9 +18,7 @@ class KafkaExample extends CornichonFeature with KafkaDsl {
         message = "I am a plain string"
       )
 
-      When I read_from_topic(
-        topic = "cornichon"
-      )
+      When I read_from_topic("cornichon")
 
       Then assert kafka("cornichon").topic_is("cornichon")
       Then assert kafka("cornichon").key_is("success")
@@ -31,23 +29,18 @@ class KafkaExample extends CornichonFeature with KafkaDsl {
       Given I put_topic(
         topic = "cornichon",
         key = "json",
-        message =
-          """{
-            | "coffee"   : "black",
-            | "cornichon": "green"
-            |}""".stripMargin
+        message = """{ "coffee": "black", "cornichon": "green" }"""
       )
 
-      When I read_from_topic(
-        topic = "cornichon"
+      When I read_from_topic("cornichon")
+      Then assert kafka("cornichon").key_is("json")
+      Then assert kafka("cornichon").message_value.ignoring("coffee").is("""
+        {
+          "cornichon": "green"
+        }
+        """
       )
-
-      Then assert kafka("cornichon").message_value.ignoring("coffee").is(
-        """{
-          | "cornichon": "green"
-          |}""".stripMargin)
     }
-
   }
 
   beforeFeature {

--- a/cornichon-kafka/src/test/scala/com/github/agourlay/kafka/kafka/KafkaExample.scala
+++ b/cornichon-kafka/src/test/scala/com/github/agourlay/kafka/kafka/KafkaExample.scala
@@ -6,8 +6,8 @@ import net.manub.embeddedkafka.{ EmbeddedKafka, EmbeddedKafkaConfig }
 
 class KafkaExample extends CornichonFeature with KafkaDsl {
 
-  override val kafkaBootstrapServersHost = "localhost"
-  override val kafkaBootstrapServersPort = 9092
+  override lazy val kafkaBootstrapServersHost = "localhost"
+  override lazy val kafkaBootstrapServersPort = 9092
 
   def feature = Feature("Kafka DSL") {
 

--- a/cornichon-kafka/src/test/scala/com/github/agourlay/kafka/kafka/KafkaExample.scala
+++ b/cornichon-kafka/src/test/scala/com/github/agourlay/kafka/kafka/KafkaExample.scala
@@ -6,6 +6,9 @@ import net.manub.embeddedkafka.{ EmbeddedKafka, EmbeddedKafkaConfig }
 
 class KafkaExample extends CornichonFeature with KafkaDsl {
 
+  override val kafkaBootstrapServersHost = "localhost"
+  override val kafkaBootstrapServersPort = 9092
+
   def feature = Feature("Kafka DSL") {
 
     Scenario("write and read arbitrary Strings to/from topic") {
@@ -48,11 +51,13 @@ class KafkaExample extends CornichonFeature with KafkaDsl {
   }
 
   beforeFeature {
-    implicit val kafkaConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
-      kafkaPort = 9092,
-      customBrokerProperties = Map("group.initial.rebalance.delay.ms" -> "10")
-    )
-    EmbeddedKafka.start()
+    // start an embedded kafka for the tests
+    EmbeddedKafka.start() {
+      EmbeddedKafkaConfig(
+        kafkaPort = kafkaBootstrapServersPort,
+        customBrokerProperties = Map("group.initial.rebalance.delay.ms" -> "10")
+      )
+    }
     ()
   }
 


### PR DESCRIPTION
This PR reworks the Kafka DSL to enable users to work with dynamic configuration.

