### PR TITLE
Fix date/date-time/time matchers thread safety

### DIFF
--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/matchers/Matcher.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/matchers/Matcher.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.matchers
 
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 import java.util.regex.Pattern
 
@@ -14,9 +15,6 @@ case class Matcher(key: String, description: String, predicate: Json ⇒ Boolean
 }
 
 object Matchers {
-  private val sdfDate = new java.text.SimpleDateFormat("yyyy-MM-dd")
-  private val sdfDateTime = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-  private val sdfTime = new java.text.SimpleDateFormat("HH:mm:ss.SSS")
 
   val isPresent = Matcher(
     key = "is-present",
@@ -86,19 +84,19 @@ object Matchers {
 
   val anyDate = Matcher(
     key = "any-date",
-    description = "checks if the field is a 'yyyy-MM-dd' date",
-    predicate = _.asString.exists(s ⇒ Try(sdfDate.parse(s)).isSuccess)
+    description = "checks if the field is an ISO date (e.g. 'yyyy-MM-dd')",
+    predicate = _.asString.exists(s ⇒ Try(DateTimeFormatter.ISO_DATE.parse(s)).isSuccess)
   )
 
   val anyDateTime = Matcher(
     key = "any-date-time",
-    description = """checks if the field is a "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" datetime""",
-    predicate = _.asString.exists(s ⇒ Try(sdfDateTime.parse(s)).isSuccess)
+    description = """checks if the field is an ISO instant (e.g. "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")""",
+    predicate = _.asString.exists(s ⇒ Try(DateTimeFormatter.ISO_INSTANT.parse(s)).isSuccess)
   )
 
   val anyTime = Matcher(
     key = "any-time",
-    description = "checks if the field is a 'HH:mm:ss.SSS' time",
-    predicate = _.asString.exists(s ⇒ Try(sdfTime.parse(s)).isSuccess)
+    description = "checks if the field is an ISO time (e.g. 'HH:mm:ss.SSS')",
+    predicate = _.asString.exists(s ⇒ Try(DateTimeFormatter.ISO_TIME.parse(s)).isSuccess)
   )
 }

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/matchers/MatchersSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/matchers/MatchersSpec.scala
@@ -1,16 +1,21 @@
 package com.github.agourlay.cornichon.matchers
 
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
 import cats.scalatest.EitherValues
-import org.scalacheck.Gen
-import org.scalatest._
 import com.github.agourlay.cornichon.matchers.Matchers._
 import io.circe.Json
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalatest._
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 class MatchersSpec extends WordSpec
   with Matchers
   with ScalaCheckPropertyChecks
   with EitherValues {
+
+  import MatchersSpec._
 
   "Matchers" when {
     "any-integer" must {
@@ -68,5 +73,32 @@ class MatchersSpec extends WordSpec
         }
       }
     }
+
+    "any-date-time" must {
+      "correct for all ISO-compliant values, including Y10K+ dates" in {
+        forAll(instantGen) { instant ⇒
+          anyDateTime.predicate(Json.fromString(DateTimeFormatter.ISO_INSTANT.format(instant))) should be(true)
+        }
+      }
+
+      "correct in parallel" in {
+        1.to(64)
+          .map(_ ⇒ reasonablyRandomInstantGen.sample)
+          .par
+          .foreach { instant ⇒
+            anyDateTime.predicate(Json.fromString(DateTimeFormatter.ISO_INSTANT.format(instant.get))) should be(true)
+          }
+      }
+    }
   }
+}
+
+object MatchersSpec {
+  val reasonablyRandomInstantGen: Gen[Instant] = for {
+    randomOffset ← Arbitrary.arbLong.arbitrary
+  } yield Instant.now().plusMillis(randomOffset % 1000000000000L)
+
+  val instantGen: Gen[Instant] = for {
+    randomOffset ← Arbitrary.arbLong.arbitrary
+  } yield Instant.now().plusMillis(randomOffset)
 }


### PR DESCRIPTION
The "any-time", "any-date" & "any-date-time" matchers used the
`SimpleDateFormat` underneath, which is non-thread-safe for parsing due
to internal mutability. This caused errors in some cases when running
cornichon specs in a parallel way. E.g. the IntelliJ IDEA runner seems
to always run the specs serially, but SBT may run them in parallel,
causing the same set of specs to either succeed or fail depending on the
running environment.

Until Java 8 the common fix was to use a drop-in
replacement from Apache commons, `FastDateFormat`, implementing the same
`DateFormat` interface. But Java 8's java.time brought the newer,
immutable `DateTimeFormatter` class with default implementations for
most of the common temporal formats.

The added benefit is the less rigid checking against optional string
temporal value representation components, such as milliseconds in a
timestamp.