### PR TITLE
can use different json encoders for each variable

### DIFF
--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/http/QueryGQLSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/http/QueryGQLSpec.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.http
 
+import cats.implicits._
 import io.circe.Json
 import org.scalatest.{ Matchers, OptionValues, WordSpec }
 
@@ -13,12 +14,14 @@ class QueryGQLSpec extends WordSpec
       val withVariables = gql.withVariables(
         "booleanVar" -> true,
         "intVar" -> 42,
-        "stringVar" -> "hello"
+        "stringVar" -> "hello",
+        "arrayOfString" -> """ ["value1", "value2"] """
       )
       withVariables.variables.value should be(Map(
         "booleanVar" -> Json.True,
         "intVar" -> Json.fromInt(42),
-        "stringVar" -> Json.fromString("hello")
+        "stringVar" -> Json.fromString("hello"),
+        "arrayOfString" -> Json.fromValues(Json.fromString("value1") :: Json.fromString("value2") :: Nil)
       ))
     }
   }

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/http/QueryGQLSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/http/QueryGQLSpec.scala
@@ -1,0 +1,26 @@
+package com.github.agourlay.cornichon.http
+
+import io.circe.Json
+import org.scalatest.{ Matchers, OptionValues, WordSpec }
+
+class QueryGQLSpec extends WordSpec
+  with Matchers
+  with OptionValues {
+
+  "QueryGQL" must {
+    "allow adding variables of different types" in {
+      val gql = QueryGQL("url", QueryGQL.emptyDocument, None, None, Nil, Nil)
+      val withVariables = gql.withVariables(
+        "booleanVar" -> true,
+        "intVar" -> 42,
+        "stringVar" -> "hello"
+      )
+      withVariables.variables.value should be(Map(
+        "booleanVar" -> Json.True,
+        "intVar" -> Json.fromInt(42),
+        "stringVar" -> Json.fromString("hello")
+      ))
+    }
+  }
+
+}


### PR DESCRIPTION
When using the `withVariables` with variables of different types, like:
```
gql.withVariables(
        "booleanVar" -> true,
        "intVar" -> 42,
        "stringVar" -> "hello"
      )
```
the compiler tries to find one `Encoder` instance for all values, and fails to do so:
```
[error] /Users/yannsimon/projects/cornichon/cornichon-core/src/test/scala/com/github/agourlay/cornichon/http/QueryGQLSpec.scala:13:44: diverging implicit expansion for type io.circe.Encoder[A]
[error] starting with method encodeMapLike in object Encoder
[error]       val withVariables = gql.withVariables(
[error]                                            ^
```

This changes introduces `VarValue` to capture the suitable encoder for each element, instead of the whole map values.

The type class `Show`  does not seem to be used. I therefore have not considered it.

A downside is that it creates one `VarValue` instance for each element, even if they are all of the same type.
We could fix that by introducing a cache based on the type of the value.
I think that the complexity introduced by this cache is not worth it, compared to the number of variables that one test typically uses.
