### PR TITLE
introduce <scenario-unique-number> and <global-unique-number>

### DIFF
--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/RandomContext.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/RandomContext.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.core
 
+import java.util.concurrent.atomic.AtomicLong
 import scala.util.Random
 
 trait RandomContext {
@@ -11,6 +12,7 @@ trait RandomContext {
   def nextInt(): Int
   def nextInt(n: Int): Int
   def nextLong(): Long
+  def uniqueLong(): Long
   def nextString(length: Int): String
   def nextPrintableChar(): Char
   def alphanumeric(length: Int): String
@@ -31,6 +33,8 @@ class MutableRandomContext(seed: Long, seededRandom: Random) extends RandomConte
   def nextPrintableChar(): Char = seededRandom.nextPrintableChar()
   def alphanumeric(length: Int): String = seededRandom.alphanumeric.take(length).mkString("")
   def shuffle[T](xs: Iterable[T]): Iterable[T] = seededRandom.shuffle(xs)
+  private val atomicLong = new AtomicLong(1L)
+  def uniqueLong(): Long = atomicLong.getAndIncrement()
 }
 
 object RandomContext {

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/RunState.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/RunState.scala
@@ -55,6 +55,9 @@ case class RunState(
     def fillPlaceholders(input: String): Either[CornichonError, String] =
       PlaceholderResolver.fillPlaceholders(input)(session, randomContext, customExtractors)
 
+    def fillSessionPlaceholders(input: String): Either[CornichonError, String] =
+      PlaceholderResolver.fillPlaceholders(input)(session, randomContext, customExtractors, sessionOnlyMode = true)
+
     def fillPlaceholders(params: Seq[(String, String)]): Either[CornichonError, List[(String, String)]] =
       PlaceholderResolver.fillPlaceholdersMany(params)(session, randomContext, customExtractors)
 

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/ScenarioContext.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/ScenarioContext.scala
@@ -11,6 +11,7 @@ trait ScenarioContext {
   // PlaceholderResolver
   def fillPlaceholders[A: Resolvable](input: A): Either[CornichonError, A]
   def fillPlaceholders(input: String): Either[CornichonError, String]
+  def fillSessionPlaceholders(input: String): Either[CornichonError, String]
   def fillPlaceholders(params: Seq[(String, String)]): Either[CornichonError, List[(String, String)]]
 
   // MatcherResolver
@@ -25,6 +26,7 @@ object ScenarioContext {
 
     def fillPlaceholders[A: Resolvable](input: A): Either[CornichonError, A] = Right(input)
     def fillPlaceholders(input: String): Either[CornichonError, String] = Right(input)
+    def fillSessionPlaceholders(input: String): Either[CornichonError, String] = Right(input)
     def fillPlaceholders(params: Seq[(String, String)]): Either[CornichonError, List[(String, String)]] = Right(params.toList)
 
     def findAllMatchers(input: String): Either[CornichonError, List[Matcher]] = rightNil

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/ScenarioRunner.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/ScenarioRunner.scala
@@ -126,7 +126,7 @@ object ScenarioRunner {
   }
 
   private def prepareAndRunStep(step: Step, runState: RunState): Task[(RunState, FailedStep Either Done)] =
-    runState.scenarioContext.fillPlaceholders(step.title)
+    runState.scenarioContext.fillSessionPlaceholders(step.title) //resolving only session placeholders as built-in generators have side effects
       .map(step.setTitle)
       .fold(
         ce => Task.now(ScenarioRunner.handleErrors(step, runState, NonEmptyList.one(ce))),

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/resolver/PlaceholderGenerator.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/resolver/PlaceholderGenerator.scala
@@ -1,0 +1,22 @@
+package com.github.agourlay.cornichon.resolver
+
+import java.util.UUID
+
+import com.github.agourlay.cornichon.core.RandomContext
+
+case class PlaceholderGenerator(key: String, gen: RandomContext => String)
+
+object PlaceholderGenerator {
+  // RandomContext
+  val randomUUID = PlaceholderGenerator("random-uuid", rc => new UUID(rc.nextLong(), rc.nextLong()).toString)
+  val randomPositiveInteger = PlaceholderGenerator("random-positive-integer", _.nextInt(10000).toString)
+  val randomString = PlaceholderGenerator("random-string", _.nextString(5))
+  val randomAlphanumString = PlaceholderGenerator("random-alphanum-string", _.alphanumeric(5))
+  val randomBoolean = PlaceholderGenerator("random-boolean", _.nextBoolean().toString)
+  val scenarioUniqueNumber = PlaceholderGenerator("scenario-unique-number", _.uniqueLong().toString)
+
+  //Global
+  val globalUniqueNumber = PlaceholderGenerator("global-unique-number", _ => PlaceholderResolver.globalNextLong().toString)
+  val randomTimestamp = PlaceholderGenerator("random-timestamp", rc => (Math.abs(System.currentTimeMillis - rc.nextLong()) / 1000).toString)
+  val currentTimestamp = PlaceholderGenerator("current-timestamp", _ => (System.currentTimeMillis / 1000).toString)
+}

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/resolver/PlaceholderResolverSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/resolver/PlaceholderResolverSpec.scala
@@ -82,5 +82,37 @@ object PlaceholderResolverSpec extends TestSuite {
       val s = Session.newEmpty.addValueUnsafe("customer", """{"id" : "122"}""")
       assert(fillPlaceholders("<customer-id>")(s, rc, extractors) == Right("122"))
     }
+
+    test("fillPlaceholders <scenario-unique-number> starts with 1") {
+      val session = Session.newEmpty
+      val content = "<scenario-unique-number>"
+      assert(fillPlaceholders(content)(session, RandomContext.fromSeed(1L), noExtractor) == Right("1"))
+    }
+
+    test("fillPlaceholders generates unique numbers scoped to the RandomContext with <scenario-unique-number>") {
+      val session = Session.newEmpty
+      val content = "<scenario-unique-number>"
+      val rc = RandomContext.fromSeed(1L)
+      val max = 100
+      for (i <- 1 until max) {
+        assert(fillPlaceholders(content)(session, rc, noExtractor) == Right(i.toString))
+      }
+      assert(rc.uniqueLong() == max)
+      // a different RandomContext is not impacted
+      assert(fillPlaceholders(content)(session, RandomContext.fromSeed(1L), noExtractor) == Right("1"))
+    }
+
+    test("fillPlaceholders <global-unique-number> starts with 1 and is scoped globally") {
+      val session = Session.newEmpty
+      val content = "<global-unique-number>"
+      assert(fillPlaceholders(content)(session, RandomContext.fromSeed(1L), noExtractor) == Right("1"))
+      val rc = RandomContext.fromSeed(1L)
+      val max = 100
+      for (i <- 2 until max) {
+        assert(fillPlaceholders(content)(session, rc, noExtractor) == Right(i.toString))
+      }
+      // the RandomContext is not impacted
+      assert(rc.uniqueLong() == 1L)
+    }
   }
 }

--- a/cornichon-docs/docs/placeholders.md
+++ b/cornichon-docs/docs/placeholders.md
@@ -62,13 +62,15 @@ class PlaceholderFeature extends CornichonFeature {
 
 It is also possible to inject random values inside placeholders using:
 
-- ```<random-uuid>``` for a random UUID
-- ```<random-positive-integer>``` for a random Integer between 0-10000
-- ```<random-string>``` for a random String of length 5
-- ```<random-alphanum-string>``` for a random alphanumeric String of length 5
-- ```<random-boolean>``` for a random Boolean string
-- ```<random-timestamp>``` for a random timestamp
-- ```<current-timestamp>``` for the current timestamp
+- `<random-uuid>` for a random UUID
+- `<random-positive-integer>` for a random Integer between 0-10000
+- `<random-string>` for a random String of length 5
+- `<random-alphanum-string>` for a random alphanumeric String of length 5
+- `<random-boolean>` for a random Boolean string
+- `<random-timestamp>` for a random timestamp
+- `<current-timestamp>` for the current timestamp
+- `<scenario-unique-number>` for a unique number scoped per scenario
+- `<global-unique-number>` for a globally unique number across all features
 
 ```scala
 post("http://url.io/somethingWithAnId").withBody(

--- a/cornichon-test-framework/src/test/scala/com/github/agourlay/cornichon/framework/examples/UniqueNumberScenario.scala
+++ b/cornichon-test-framework/src/test/scala/com/github/agourlay/cornichon/framework/examples/UniqueNumberScenario.scala
@@ -1,0 +1,35 @@
+package com.github.agourlay.cornichon.framework.examples
+
+import com.github.agourlay.cornichon.CornichonFeature
+
+class UniqueNumberScenario extends CornichonFeature {
+
+  // running sequentially to get deterministic global assertions
+  override lazy val executeScenariosInParallel: Boolean = false
+
+  def feature = Feature("Example of unique number generation") {
+
+    Scenario("unique number scoped to Scenario") {
+      When I save("my-counter" -> "<scenario-unique-number>")
+      And I save("my-other-counter" -> "<scenario-unique-number>")
+      Then assert session_value("my-counter").is("1")
+      Then assert session_value("my-other-counter").is("2")
+    }
+
+    Scenario("unique number scoped globally (1)") {
+      When I save("my-counter" -> "<global-unique-number>")
+      Then assert session_value("my-counter").is("1")
+    }
+
+    Scenario("unique number scoped globally (2)") {
+      When I save("my-counter" -> "<global-unique-number>")
+      Then assert session_value("my-counter").is("2")
+    }
+
+    Scenario("unique number scoped globally (3)") {
+      When I save("my-counter" -> "<global-unique-number>")
+      Then assert session_value("my-counter").is("3")
+    }
+
+  }
+}


### PR DESCRIPTION
This PR adds supports for unique numbers generators at the scenario and global scope.

```scala
class UniqueNumberScenario extends CornichonFeature {

  // running sequentially to get deterministic global assertions
  override lazy val executeScenariosInParallel: Boolean = false

  def feature = Feature("Example of unique number generation") {

    Scenario("unique number scoped to Scenario") {
      When I save("my-counter" -> "<scenario-unique-number>")
      And I save("my-other-counter" -> "<scenario-unique-number>")
      Then assert session_value("my-counter").is("1")
      Then assert session_value("my-other-counter").is("2")
    }

    Scenario("unique number scoped globally (1)") {
      When I save("my-counter" -> "<global-unique-number>")
      Then assert session_value("my-counter").is("1")
    }

    Scenario("unique number scoped globally (2)") {
      When I save("my-counter" -> "<global-unique-number>")
      Then assert session_value("my-counter").is("2")
    }

    Scenario("unique number scoped globally (3)") {
      When I save("my-counter" -> "<global-unique-number>")
      Then assert session_value("my-counter").is("3")
    }

  }
```

An important refactoring was necessary as by default, all the step titles are rendered which causes an issue when the resolution performs a side effect.

This issue was already reported https://github.com/agourlay/cornichon/issues/177

The solution proposed here is to resolve only deterministic placeholders in titles.