### PR TITLE
JsonStepBuild can compare the previous and the current value

### DIFF
--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/SessionSteps.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/SessionSteps.scala
@@ -77,11 +77,8 @@ object SessionSteps {
       action = sc => Assertion.either {
         for {
           current <- sc.session.get(key)
-          previous <- sc.session.getPrevious(key)
-        } yield previous match {
-          case None                => Assertion.failWith(s"no previous value available to compare to current $current")
-          case Some(previousValue) => GenericEqualityAssertion(current, previousValue)
-        }
+          previous <- sc.session.getMandatoryPrevious(key)
+        } yield GenericEqualityAssertion(current, previous)
       }
     )
 
@@ -90,11 +87,8 @@ object SessionSteps {
       action = sc => Assertion.either {
         for {
           current <- sc.session.get(key)
-          previous <- sc.session.getPrevious(key)
-        } yield previous match {
-          case None                => Assertion.failWith(s"no previous value available to compare to current $current")
-          case Some(previousValue) => GenericEqualityAssertion(current, previousValue, negate = true)
-        }
+          previous <- sc.session.getMandatoryPrevious(key)
+        } yield GenericEqualityAssertion(current, previous, negate = true)
       }
     )
 
@@ -104,11 +98,8 @@ object SessionSteps {
       action = sc => Assertion.either {
         for {
           current <- sc.session.get(key)
-          previous <- sc.session.getPrevious(key)
-        } yield previous match {
-          case None                => Assertion.failWith(s"no previous value available to compare to current $current")
-          case Some(previousValue) => comp(previousValue, current)
-        }
+          previous <- sc.session.getMandatoryPrevious(key)
+        } yield comp(previous, current)
       }
     )
 

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/core/SessionProperties.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/core/SessionProperties.scala
@@ -173,6 +173,14 @@ object SessionProperties extends Properties("Session") {
       }
     }
 
+  property("getMandatoryPrevious fails if the key has only one value") =
+    forAll(keyGen, valueGen) { (key, firstValue) =>
+      val s = Session.newEmpty.addValueUnsafe(key, firstValue)
+      Claim {
+        s.getMandatoryPrevious(key).leftMap(_.renderedMessage) == Left(s"key '$key' does not have previous value in session\n$key -> Values($firstValue)")
+      }
+    }
+
   property("getList error if one of the key does not exist") =
     forAll(keyGen, keyGen, valueGen, valueGen) { (firstKey, secondKey, firstValue, secondValue) =>
       val s2 = Session
@@ -189,6 +197,14 @@ object SessionProperties extends Properties("Session") {
       val s = Session.newEmpty.addValueUnsafe(key, firstValue).addValueUnsafe(key, secondValue)
       Claim {
         s.getPrevious(key) == Right(Some(firstValue))
+      }
+    }
+
+  property("getMandatoryPrevious returns the previous value in session") =
+    forAll(keyGen, valueGen, valueGen) { (key, firstValue, secondValue) =>
+      val s = Session.newEmpty.addValueUnsafe(key, firstValue).addValueUnsafe(key, secondValue)
+      Claim {
+        s.getMandatoryPrevious(key) == Right(firstValue)
       }
     }
 


### PR DESCRIPTION
This is handy when comparing state after transition with `cornichon-check`.

For instance if you have saved a value twice in the `cutomer` key following an update transition.

```scala
And assert session_value("customer").asJson.path("version")
  .compareWithPreviousValue[Int]{ case (prev, current) => GenericEqualityAssertion(prev + 1, current) }
``` 

Any type can be used as target as long as there is a `io.circe.Decoder` for it.