### PR TITLE
feat(core): sttp based client implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,6 +118,9 @@ lazy val core =
       testFrameworks += new TestFramework("utest.runner.Framework"),
       libraryDependencies ++= Seq(
         library.http4sClient,
+        library.sttp,
+        library.sttpAsync,
+        library.sttpHttp4s,
         library.http4sCirce,
         library.fs2Io,
         library.catsCore,
@@ -296,6 +299,7 @@ lazy val library =
       val openPojo      = "0.8.13"
       val decline       = "1.3.0"
       val scalaXml      = "2.0.0-M5"
+      val sttp          = "3.1.6"
     }
     val claimant      = "org.typelevel"                  %% "claimant"             % Version.claimant
     val catsCore      = "org.typelevel"                  %% "cats-core"            % Version.cats
@@ -316,6 +320,9 @@ lazy val library =
     val monixReactive = "io.monix"                       %% "monix-reactive"       % Version.monix
     val sbtTest       = "org.scala-sbt"                  %  "test-interface"       % Version.sbtTest
     val http4sClient  = "org.http4s"                     %% "http4s-blaze-client"  % Version.http4s
+    val sttp          = "com.softwaremill.sttp.client3"  %% "core"                 % Version.sttp
+    val sttpAsync     = "com.softwaremill.sttp.client3"  %% "async-http-client-backend-monix" % Version.sttp
+    val sttpHttp4s    = "com.softwaremill.sttp.client3"  %% "http4s-backend"       % Version.sttp
     val http4sServer  = "org.http4s"                     %% "http4s-blaze-server"  % Version.http4s
     val http4sCirce   = "org.http4s"                     %% "http4s-circe"         % Version.http4s
     val http4sDsl     = "org.http4s"                     %% "http4s-dsl"           % Version.http4s

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Config.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Config.scala
@@ -15,7 +15,8 @@ case class Config(
     failOnDuplicateHeaders: Boolean = false,
     addAcceptGzipByDefault: Boolean = true,
     disableCertificateVerification: Boolean = false,
-    followRedirect: Boolean = false)
+    followRedirect: Boolean = false,
+    httpBackend: Option[String] = None)
 
 object Config {
   implicit val hint = ProductHint[Config](allowUnknownKeys = false, fieldMapping = ConfigFieldMapping(CamelCase, CamelCase))

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/client/Http4sClient.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/client/Http4sClient.scala
@@ -1,118 +1,97 @@
 package com.github.agourlay.cornichon.http.client
 
-import java.security.SecureRandom
-import java.security.cert.X509Certificate
-
 import cats.Show
 import cats.data.EitherT
+import cats.effect._
 import cats.syntax.either._
-import cats.syntax.show._
 import com.github.agourlay.cornichon.core.{ CornichonError, CornichonException, Done }
 import com.github.agourlay.cornichon.http.HttpMethods._
-import com.github.agourlay.cornichon.http._
 import com.github.agourlay.cornichon.http.HttpService._
 import com.github.agourlay.cornichon.http.HttpStreams.SSE
+import com.github.agourlay.cornichon.http._
 import com.github.agourlay.cornichon.util.Caching
-import io.circe.Json
-import io.circe.generic.auto._
-import io.circe.syntax._
-import javax.net.ssl.{ SSLContext, TrustManager, X509TrustManager }
+import io.circe.syntax.EncoderOps
+import io.circe.{ Encoder, Json }
+import io.netty.handler.ssl.{ ApplicationProtocolConfig, ClientAuth, IdentityCipherSuiteFilter, JdkSslContext }
 import monix.eval.Task
 import monix.eval.Task._
 import monix.execution.Scheduler
-import org.http4s._
+import monix.reactive.Observable
+import org.asynchttpclient.{ AsyncHttpClient, DefaultAsyncHttpClient, DefaultAsyncHttpClientConfig }
 import org.http4s.client.blaze.BlazeClientBuilder
-import org.http4s.client.middleware.{ GZip, FollowRedirect }
+import org.http4s.client.middleware.{ FollowRedirect, GZip }
+import sttp.capabilities.Effect
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.capabilities.monix.MonixStreams
+import sttp.client3
+import sttp.client3._
+import sttp.client3.asynchttpclient.monix.AsyncHttpClientMonixBackend
+import sttp.client3.http4s._
+import sttp.client3.impl.fs2.Fs2ServerSentEvents
+import sttp.client3.impl.monix.MonixServerSentEvents
+import sttp.model.sse.ServerSentEvent
+import sttp.model.{ Uri => SttpUri }
 
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import java.util.concurrent.TimeUnit
+import javax.net.ssl.{ SSLContext, TrustManager, X509TrustManager }
+import scala.concurrent._
 import scala.concurrent.duration._
 
-class Http4sClient(
-    addAcceptGzipByDefault: Boolean,
-    disableCertificateVerification: Boolean,
-    followRedirect: Boolean)(implicit scheduler: Scheduler)
+/**
+ * @param sttp          the sttp backend
+ * @param streamHandler handler to convert sse events in to assertable JSON values
+ * @param shutdown      release effect to close the backend
+ * @tparam P the capabilities of the backend
+ * @tparam R the requirements (on the capabilities) for the request
+ *
+ *           NOTE: the type param bounds reflect the the requirements for {{SttpBackend.send}}
+ */
+final case class HttpClientBackend[P, R >: P with Effect[Task]](
+    sttp: SttpBackend[Task, P],
+    streamHandler: StreamHandler[R],
+    shutdown: Task[Unit])
+
+trait StreamHandler[R] {
+  def apply(takeWithin: FiniteDuration): RequestT[Identity, Either[String, String], R] => RequestT[Identity, Either[String, Json], R]
+}
+
+class Http4sClient[P, R >: P with Effect[Task]](backend: HttpClientBackend[P, R])
   extends HttpClient {
-
-  // Disable JDK built-in checks
-  private val sslContext = {
-    if (disableCertificateVerification) {
-      val ssl = SSLContext.getInstance("SSL")
-      val byPassTrustManagers = Array[TrustManager](new X509TrustManager() {
-        override def getAcceptedIssuers: Array[X509Certificate] = Array.empty
-        override def checkClientTrusted(x509Certificates: Array[X509Certificate], s: String) = ()
-        override def checkServerTrusted(x509Certificates: Array[X509Certificate], s: String) = ()
-      })
-      ssl.init(null, byPassTrustManagers, new SecureRandom)
-      ssl
-    } else SSLContext.getDefault
-  }
-
   // Lives for the duration of the test run
-  private val uriCache = Caching.buildCache[String, Either[CornichonError, Uri]]()
-  // Timeouts are managed within the HttpService
-  private val defaultHighTimeout = Duration.Inf
-  private val (httpClient, safeShutdown) =
-    BlazeClientBuilder(executionContext = scheduler)
-      .withSslContext(sslContext)
-      .withMaxTotalConnections(300)
-      .withMaxWaitQueueLimit(500)
-      .withIdleTimeout(defaultHighTimeout)
-      .withResponseHeaderTimeout(defaultHighTimeout)
-      .withRequestTimeout(defaultHighTimeout)
-      .allocated
-      .map {
-        case (client, shutdown) =>
-          val c1 = if (addAcceptGzipByDefault) GZip()(client) else client
-          val c2 = if (followRedirect) FollowRedirect(maxRedirects = 10)(client = c1) else c1
-          c2 -> shutdown
-      }
-      .runSyncUnsafe(10.seconds)
+  private val uriCache = Caching.buildCache[String, Either[CornichonError, SttpUri]]()
 
-  private def toHttp4sMethod(method: HttpMethod): Method = method match {
-    case DELETE  => org.http4s.Method.DELETE
-    case GET     => org.http4s.Method.GET
-    case HEAD    => org.http4s.Method.HEAD
-    case OPTIONS => org.http4s.Method.OPTIONS
-    case PATCH   => org.http4s.Method.PATCH
-    case POST    => org.http4s.Method.POST
-    case PUT     => org.http4s.Method.PUT
-    case other   => throw CornichonException(s"unsupported HTTP method ${other.name}")
+  private def toSttpRequest[A](cReq: HttpRequest[A], uri: SttpUri)(implicit ee: BodySerializer[A]): client3.Request[Either[String, String], R] = {
+    val uriWithParams = uri.addParams(cReq.params: _*)
+
+    val request = (cReq.method match {
+      case DELETE  => basicRequest.delete(uriWithParams)
+      case GET     => basicRequest.get(uriWithParams)
+      case HEAD    => basicRequest.head(uriWithParams)
+      case OPTIONS => basicRequest.options(uriWithParams)
+      case PATCH   => basicRequest.patch(uriWithParams)
+      case POST    => basicRequest.post(uriWithParams)
+      case PUT     => basicRequest.put(uriWithParams)
+      case other   => throw CornichonException(s"unsupported HTTP method ${other.name}")
+    })
+
+    cReq
+      .body.fold(request)(body => request.body(body))
+      .headers(cReq.headers.toMap)
   }
 
-  private def toHttp4sHeaders(headers: Seq[(String, String)]): List[Header] =
-    headers.iterator.map { case (n, v) => Header(n, v).parsed }.toList
-
-  private def fromHttp4sHeaders(headers: Headers): Seq[(String, String)] =
-    headers.toList.map(h => (h.name.value, h.value))
-
-  def addQueryParams(uri: Uri, moreParams: Seq[(String, String)]): Uri =
-    if (moreParams.isEmpty)
-      uri
-    else {
-      val q = Query.fromPairs(moreParams: _*)
-      // Not sure it is the most efficient way
-      uri.copy(query = Query.fromVector(uri.query.toVector ++ q.toVector))
-    }
-
-  override def runRequest[A: Show](cReq: HttpRequest[A], t: FiniteDuration)(implicit ee: EntityEncoder[Task, A]): EitherT[Task, CornichonError, HttpResponse] =
+  override def runRequest[A: Show](cReq: HttpRequest[A], t: FiniteDuration)(implicit ee: BodySerializer[A]): EitherT[Task, CornichonError, HttpResponse] =
     parseUri(cReq.url).fold(
       e => EitherT.left[HttpResponse](Task.now(e)),
       uri => EitherT {
-        val req = Request[Task](toHttp4sMethod(cReq.method))
-        val completeRequest = cReq.body.fold(req)(b => req.withEntity(b))
-          .putHeaders(toHttp4sHeaders(cReq.headers): _*) // `withEntity` adds `Content-Type` so we set the headers afterwards to have the possibility to override it
-          .withUri(addQueryParams(uri, cReq.params))
-        val cornichonResponse = httpClient.run(completeRequest).use { http4sResp =>
-          http4sResp
-            .bodyText
-            .compile
-            .string
-            .map { decodedBody =>
-              HttpResponse(
-                status = http4sResp.status.code,
-                headers = fromHttp4sHeaders(http4sResp.headers),
-                body = decodedBody
-              ).asRight[CornichonError]
-            }
+        val cornichonResponse: Task[Either[CornichonError, HttpResponse]] = toSttpRequest(cReq, uri).send[Task, P](backend.sttp).map { response =>
+          val bodyValue = response.body.fold(identity, identity)
+          HttpResponse(
+            status = response.code.code,
+            headers = response.headers.map(header => (header.name, header.value)),
+            body = bodyValue
+          ).asRight[CornichonError]
         }
 
         val timeout = Task.delay(TimeoutErrorAfter(cReq, t).asLeft).delayExecution(t)
@@ -129,24 +108,18 @@ class Http4sClient(
     parseUri(streamReq.url).fold(
       e => EitherT.left[HttpResponse](Task.now(e)),
       uri => EitherT {
-        val req = Request[Task](org.http4s.Method.GET)
-          .withHeaders(Headers(toHttp4sHeaders(streamReq.addHeaders(sseHeader).headers)))
-          .withUri(addQueryParams(uri, streamReq.params))
+        val sseRequest = backend.streamHandler(streamReq.takeWithin)(basicRequest
+          .get(uri.addParams(streamReq.params.toMap))
+          .headers(streamReq.addHeaders(sseHeader).headers.toMap))
 
-        val cornichonResponse = httpClient.run(req).use { http4sResp =>
-          http4sResp
-            .body
-            .through(ServerSentEvent.decoder)
-            .interruptAfter(streamReq.takeWithin)
-            .compile
-            .toList
-            .map { events =>
-              HttpResponse(
-                status = http4sResp.status.code,
-                headers = fromHttp4sHeaders(http4sResp.headers),
-                body = Json.fromValues(events.map(_.asJson)).show
-              ).asRight[CornichonError]
-            }
+        val cornichonResponse: Task[Either[CornichonError, HttpResponse]] = sseRequest.send(backend.sttp).map { streamResponse =>
+          val bodyValue: String = streamResponse.body.fold(identity, _.noSpaces)
+
+          HttpResponse(
+            status = streamResponse.code.code,
+            headers = streamResponse.headers.map(header => (header.name, header.value)),
+            body = bodyValue
+          ).asRight[CornichonError]
         }
 
         val timeout = Task.delay(TimeoutErrorAfter(streamReq, t).asLeft).delayExecution(t)
@@ -165,14 +138,137 @@ class Http4sClient(
     }
 
   def shutdown(): Task[Done] =
-    safeShutdown.map { _ => uriCache.invalidateAll(); Done }
+    backend.shutdown.map { _ => uriCache.invalidateAll(); Done }
 
   def paramsFromUrl(url: String): Either[CornichonError, List[(String, String)]] =
     if (url.contains('?'))
-      parseUri(url).map(_.params.toList)
+      parseUri(url).map(_.paramsSeq.toList)
     else
       rightNil
 
-  def parseUri(uri: String): Either[CornichonError, Uri] =
-    uriCache.get(uri, u => Uri.fromString(u).leftMap(e => MalformedUriError(u, e.message)))
+  def parseUri(uri: String): Either[CornichonError, SttpUri] =
+    uriCache.get(uri, u => SttpUri.parse(u).leftMap(error => MalformedUriError(u, error)))
+}
+
+object SttpClient {
+
+  sealed trait BackendOption {
+    val key: String
+  }
+
+  case object Https4BackendOption extends BackendOption {
+    val key: String = "https"
+  }
+
+  case object AsyncHttpOption extends BackendOption {
+    val key: String = "async"
+  }
+
+  object BackendOption {
+    def apply(key: String): BackendOption = key match {
+      case Https4BackendOption.key => Https4BackendOption
+      case AsyncHttpOption.key     => AsyncHttpOption
+    }
+  }
+
+  // an implicit `cats.effect.ContextShift` is required to create an instance of `cats.effect.Concurrent`
+  // for `cats.effect.IO`,  as well as a `cats.effect.Blocker` instance.
+  // Note that you'll probably want to use a different thread pool for blocking.
+  private val blocker: cats.effect.Blocker = Blocker.liftExecutionContext(ExecutionContext.global)
+
+  // Timeouts are managed within the HttpService
+  private val defaultHighTimeout = Duration(60, TimeUnit.MINUTES)
+
+  private val maxConnections: Int = 300
+
+  private implicit val sseEncoder: Encoder.AsObject[ServerSentEvent] = io.circe.generic.semiauto.deriveEncoder[ServerSentEvent]
+
+  // Disable JDK built-in checks
+  private def createSslContext(disableCertificateVerification: Boolean): SSLContext = {
+    if (disableCertificateVerification) {
+      val ssl = SSLContext.getInstance("SSL")
+      val byPassTrustManagers = Array[TrustManager](new X509TrustManager() {
+        override def getAcceptedIssuers: Array[X509Certificate] = Array.empty
+
+        override def checkClientTrusted(x509Certificates: Array[X509Certificate], s: String) = ()
+
+        override def checkServerTrusted(x509Certificates: Array[X509Certificate], s: String) = ()
+      })
+      ssl.init(null, byPassTrustManagers, new SecureRandom)
+      ssl
+    } else SSLContext.getDefault
+  }
+
+  def blazeClientBuilder(disableCertificateVerification: Boolean)(implicit scheduler: Scheduler): BlazeClientBuilder[Task] = {
+    BlazeClientBuilder(executionContext = scheduler)
+      .withSslContext(createSslContext(disableCertificateVerification))
+      .withMaxTotalConnections(maxConnections)
+      .withMaxWaitQueueLimit(500)
+      .withIdleTimeout(defaultHighTimeout)
+      .withResponseHeaderTimeout(defaultHighTimeout)
+      .withRequestTimeout(defaultHighTimeout)
+  }
+
+  private val fs2StreamHandler: StreamHandler[Effect[Task] with Fs2Streams[Task]] = new StreamHandler[Effect[Task] with Fs2Streams[Task]] {
+    override def apply(takeWithin: FiniteDuration) = request => {
+      def parseEvents(stream: fs2.Stream[Task, ServerSentEvent]): Task[Json] = {
+        stream.compile.toList.map(events => Json.fromValues(events.map(_.asJson)))
+      }
+
+      request.response(asStream(Fs2Streams[Task])(stream => parseEvents(stream.through(Fs2ServerSentEvents.parse).interruptAfter(takeWithin))))
+    }
+  }
+
+  private val monixStreamHandler: StreamHandler[MonixStreams with Effect[Task]] = new StreamHandler[MonixStreams with Effect[Task]] {
+    override def apply(takeWithin: FiniteDuration) = request => {
+      def parseEvents(stream: Observable[ServerSentEvent]): Task[Json] = {
+        stream
+          .foldLeftL(Vector.empty[ServerSentEvent])(_ :+ _)
+          .map(events => Json.fromValues(events.map(_.asJson)))
+      }
+
+      request.response(asStream(MonixStreams)(stream => parseEvents(stream.transform(MonixServerSentEvents.parse).takeByTimespan(takeWithin))))
+    }
+  }
+
+  def apply(backend: BackendOption)(
+    addAcceptGzipByDefault: Boolean,
+    disableCertificateVerification: Boolean,
+    followRedirect: Boolean)(implicit scheduler: Scheduler): Http4sClient[_, _] = backend match {
+    case Https4BackendOption =>
+      (for {
+        clientWithShutdown <- blazeClientBuilder(disableCertificateVerification)
+          .allocated
+          .map {
+            case (client, shutdown) =>
+              val c1 = if (addAcceptGzipByDefault) GZip()(client) else client
+              val c2 = if (followRedirect) FollowRedirect(maxRedirects = 10)(client = c1) else c1
+              c2 -> shutdown
+          }
+        (client, shutdown) = clientWithShutdown
+        http4sBackend: SttpBackend[Task, Fs2Streams[Task]] = Http4sBackend.usingClient(client, blocker)
+        streamHandler: StreamHandler[Effect[Task] with Fs2Streams[Task]] = fs2StreamHandler
+      } yield new Http4sClient(HttpClientBackend(http4sBackend, streamHandler, shutdown))).runSyncUnsafe(10.seconds)
+
+    case AsyncHttpOption =>
+      val config = new DefaultAsyncHttpClientConfig.Builder()
+        .setRequestTimeout(defaultHighTimeout.toMillis.toInt)
+        .setPooledConnectionIdleTimeout(defaultHighTimeout.toMillis.toInt)
+        .setMaxConnections(maxConnections)
+        .setSslContext(new JdkSslContext(
+          createSslContext(disableCertificateVerification),
+          false,
+          null,
+          IdentityCipherSuiteFilter.INSTANCE,
+          ApplicationProtocolConfig.DISABLED,
+          ClientAuth.NONE,
+          null,
+          false))
+        .setCompressionEnforced(addAcceptGzipByDefault)
+        .build()
+
+      val asyncHttpClient: AsyncHttpClient = new DefaultAsyncHttpClient(config)
+      val backend = AsyncHttpClientMonixBackend.usingClient(asyncHttpClient)
+      new Http4sClient(HttpClientBackend(backend, monixStreamHandler, backend.close()))
+  }
 }

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/client/HttpClient.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/client/HttpClient.scala
@@ -3,15 +3,15 @@ package com.github.agourlay.cornichon.http.client
 import cats.Show
 import cats.data.EitherT
 import com.github.agourlay.cornichon.core.{ CornichonError, Done }
-import com.github.agourlay.cornichon.http.{ HttpResponse, HttpRequest, HttpStreamedRequest }
+import com.github.agourlay.cornichon.http.{ HttpRequest, HttpResponse, HttpStreamedRequest }
 import monix.eval.Task
-import org.http4s.EntityEncoder
+import sttp.client3.BodySerializer
 
 import scala.concurrent.duration.FiniteDuration
 
 trait HttpClient {
 
-  def runRequest[A: Show](cReq: HttpRequest[A], t: FiniteDuration)(implicit ee: EntityEncoder[Task, A]): EitherT[Task, CornichonError, HttpResponse]
+  def runRequest[A: Show](cReq: HttpRequest[A], t: FiniteDuration)(implicit bodySer: BodySerializer[A]): EitherT[Task, CornichonError, HttpResponse]
 
   def openStream(req: HttpStreamedRequest, t: FiniteDuration): Task[Either[CornichonError, HttpResponse]]
 

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/client/NoOpHttpClient.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/client/NoOpHttpClient.scala
@@ -4,15 +4,15 @@ import cats.Show
 import cats.data.EitherT
 import cats.syntax.either._
 import com.github.agourlay.cornichon.core.Done
-import com.github.agourlay.cornichon.http.{ HttpResponse, HttpRequest, HttpStreamedRequest }
+import com.github.agourlay.cornichon.http.{ HttpRequest, HttpResponse, HttpStreamedRequest }
 import monix.eval.Task
-import org.http4s.EntityEncoder
+import sttp.client3.BodySerializer
 
 import scala.concurrent.duration.FiniteDuration
 
 class NoOpHttpClient extends HttpClient {
 
-  def runRequest[A: Show](cReq: HttpRequest[A], t: FiniteDuration)(implicit ee: EntityEncoder[Task, A]) =
+  def runRequest[A: Show](cReq: HttpRequest[A], t: FiniteDuration)(implicit bodySer: BodySerializer[A]) =
     EitherT.apply(Task.now(HttpResponse(200, Nil, "NoOpBody").asRight))
 
   def openStream(req: HttpStreamedRequest, t: FiniteDuration) =

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/http/Http4sClientSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/http/Http4sClientSpec.scala
@@ -1,23 +1,25 @@
 package com.github.agourlay.cornichon.http
 
-import com.github.agourlay.cornichon.http.client.Http4sClient
+import com.github.agourlay.cornichon.http.client.SttpClient
+import com.github.agourlay.cornichon.http.client.SttpClient.Https4BackendOption
 import monix.execution.Scheduler.Implicits.global
 import utest._
 
 object Http4sClientSpec extends TestSuite {
 
-  private val client = new Http4sClient(true, true, true)
+  private val client = SttpClient(Https4BackendOption)(addAcceptGzipByDefault = true, disableCertificateVerification = true, followRedirect = true)
 
   override def utestAfterAll(): Unit = {
-    client.shutdown().runSyncUnsafe()
+    client.shutdown.runSyncUnsafe()
   }
 
   def tests = Tests {
     test("conserves duplicates http params") {
       val uri = client.parseUri("http://web.com").valueUnsafe
-      val finalUri = client.addQueryParams(uri, List("p1" -> "v1", "p1" -> "v1'", "p2" -> "v2"))
-      assert(finalUri.query.multiParams("p1") == "v1" :: "v1'" :: Nil)
-      assert(finalUri.query.multiParams("p2") == "v2" :: Nil)
+      val finalUri = uri.addParams("p1" -> "v1", "p1" -> "v1'", "p2" -> "v2")
+
+      assert(finalUri.params.getMulti("p1").contains(List("v1", "v1'")))
+      assert(finalUri.params.getMulti("p2").contains(List("v2")))
     }
   }
 }


### PR DESCRIPTION
This replaces the current http4s client with an implementation based on [sttp](https://github.com/softwaremill/sttp).
The default backend for sttp is still using http4s and the client is created in the same way, so this should be backwards-compatible in terms of out-of-the-box client behaviour.

Additionally, the netty async client is added (https://sttp.softwaremill.com/en/latest/backends/monix.html#using-async-http-client) as an alternative client option (somewhat related to https://github.com/agourlay/cornichon/issues/391 or client specific issues in general).

I kept some type / filenames with the `Http4s` prefix for easier review, but those should reflect `sttp`-usage eventually.

This is not abstracting over the effect type yet, so the possible clients are limited to the monix based options: https://sttp.softwaremill.com/en/latest/backends/monix.html, this is a possible improvement for the future. A flexible client selection approach is also not there yet (the possible options are hard-coded).