### PR TITLE
Optimize Session.addValues

### DIFF
--- a/benchmarks/src/main/scala/session/AddValuesBench.scala
+++ b/benchmarks/src/main/scala/session/AddValuesBench.scala
@@ -21,12 +21,12 @@ class AddValuesBench {
 
   /*
   [info] Benchmark                 (insertNumber)   Mode  Cnt        Score       Error  Units
-  [info] AddValuesBench.addValues               1  thrpt   10  7134780,331 ± 36314,364  ops/s
-  [info] AddValuesBench.addValues               2  thrpt   10  2865439,318 ± 14360,784  ops/s
-  [info] AddValuesBench.addValues               3  thrpt   10  1538325,303 ±  7640,665  ops/s
-  [info] AddValuesBench.addValues               4  thrpt   10  1251350,207 ±  6425,952  ops/s
-  [info] AddValuesBench.addValues               5  thrpt   10  1042564,281 ± 11919,693  ops/s
-  [info] AddValuesBench.addValues              10  thrpt   10   566898,054 ±  2816,408  ops/s
+  [info] AddValuesBench.addValues               1  thrpt   10  6998596,425 ± 48359,890  ops/s
+  [info] AddValuesBench.addValues               2  thrpt   10  3468311,216 ± 15327,128  ops/s
+  [info] AddValuesBench.addValues               3  thrpt   10  2037546,184 ± 11960,536  ops/s
+  [info] AddValuesBench.addValues               4  thrpt   10  1704281,695 ±  6914,468  ops/s
+  [info] AddValuesBench.addValues               5  thrpt   10  1906496,598 ± 10381,022  ops/s
+  [info] AddValuesBench.addValues              10  thrpt   10   756260,654 ±  2545,984  ops/s
   */
   @Benchmark
   def addValues() = {


### PR DESCRIPTION
This function is core to the library and should execute as fast possible.
Cats.traverse is allocating quite a lot and we can easily do without.