### PR TITLE
Http4s servers use nio1 instead of nio2

### DIFF
--- a/cornichon-http-mock/src/main/scala/com/github/agourlay/cornichon/http/server/MockHttpServer.scala
+++ b/cornichon-http-mock/src/main/scala/com/github/agourlay/cornichon/http/server/MockHttpServer.scala
@@ -49,7 +49,6 @@ class MockHttpServer[A](
       .bindHttp(port, selectedInterface)
       .withoutBanner
       .withHttpApp(mockRouter)
-      .withNio2(true)
       .resource
       .use(server => useFromAddress(s"http://${server.address.getHostString}:${server.address.getPort}"))
 

--- a/cornichon-test-framework/src/test/scala/com/github/agourlay/cornichon/framework/examples/propertyCheck/stringReverse/ReverseAPI.scala
+++ b/cornichon-test-framework/src/test/scala/com/github/agourlay/cornichon/framework/examples/propertyCheck/stringReverse/ReverseAPI.scala
@@ -28,7 +28,6 @@ class ReverseAPI extends Http4sDsl[Task] {
     BlazeServerBuilder[Task](executionContext = s)
       .bindHttp(httpPort, "localhost")
       .withoutBanner
-      .withNio2(true)
       .withHttpApp(routes.orNotFound)
       .allocated
       .map { case (_, stop) => new HttpServer(stop) }

--- a/cornichon-test-framework/src/test/scala/com/github/agourlay/cornichon/framework/examples/propertyCheck/turnstile/TurnstileAPI.scala
+++ b/cornichon-test-framework/src/test/scala/com/github/agourlay/cornichon/framework/examples/propertyCheck/turnstile/TurnstileAPI.scala
@@ -41,7 +41,6 @@ class TurnstileAPI extends Http4sDsl[Task] {
     BlazeServerBuilder[Task](executionContext = s)
       .bindHttp(httpPort, "localhost")
       .withoutBanner
-      .withNio2(true)
       .withHttpApp(routes.orNotFound)
       .allocated
       .map { case (_, stop) => new HttpServer(stop) }

--- a/cornichon-test-framework/src/test/scala/com/github/agourlay/cornichon/framework/examples/propertyCheck/webShop/WebShopAPI.scala
+++ b/cornichon-test-framework/src/test/scala/com/github/agourlay/cornichon/framework/examples/propertyCheck/webShop/WebShopAPI.scala
@@ -130,7 +130,6 @@ class WebShopAPI(maxSyncDelay: FiniteDuration) extends Http4sDsl[Task] {
     BlazeServerBuilder[Task](executionContext = s)
       .bindHttp(httpPort, "localhost")
       .withoutBanner
-      .withNio2(true)
       .withHttpApp(routes.orNotFound)
       .allocated
       .map { case (_, stop) => new HttpServer(stop) }

--- a/cornichon-test-framework/src/test/scala/com/github/agourlay/cornichon/framework/examples/superHeroes/server/SuperHeroesHttpAPI.scala
+++ b/cornichon-test-framework/src/test/scala/com/github/agourlay/cornichon/framework/examples/superHeroes/server/SuperHeroesHttpAPI.scala
@@ -172,7 +172,6 @@ class SuperHeroesHttpAPI() extends Http4sDsl[Task] {
     BlazeServerBuilder[Task](executionContext = s)
       .bindHttp(httpPort, "localhost")
       .withoutBanner
-      .withNio2(true)
       .withHttpApp(GZip(routes.orNotFound))
       .allocated
       .map { case (_, stop) => new HttpServer(stop) }


### PR DESCRIPTION
The switche to nio2 was motivated by a noisy stacktrace with nio1

https://github.com/http4s/http4s/issues/2383

However nio2 is being deprecated in 0.22 and there is no replacement

https://github.com/http4s/http4s/issues/4572

As a result we switch back to nio1 and hope the stacktrace won't be too noisy