### PR TITLE
Harden MatcherResolver

### DIFF
--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/json/CornichonJsonProperties.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/json/CornichonJsonProperties.scala
@@ -58,8 +58,8 @@ class CornichonJsonProperties extends Properties("CornichonJson") with Cornichon
     val targetValue = Json.fromString("target value")
     forAll { jos: List[JsonObject] =>
       val json = jos.foldRight(targetValue) { case (next, acc) => Json.fromJsonObject(next.add("stitch", acc)) }
-      val path = findAllPathWithValue("target value" :: Nil, json).head
-      path.run(json).contains(targetValue)
+      val (value, path) = findAllPathWithValue(Set("target value"), json).head
+      value == "target value" && path.run(json).contains(targetValue)
     }
   }
 

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/json/JsonStepsSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/json/JsonStepsSpec.scala
@@ -326,8 +326,16 @@ class JsonStepsSpec extends FunSuite with CommonTestSuite {
   }
 
   test("JsonStepBuilder.is json with matcher in object") {
-    val session = Session.newEmpty.addValuesUnsafe(testKey -> """{ "myKey" : 1, "myKeyOther" : "myOtherValue" }""")
-    val step = jsonStepBuilder.is("""{ "myKey" : *any-integer*, "myKeyOther" : *any-string* }""")
+    val session = Session.newEmpty.addValuesUnsafe(testKey -> """{ "myKeyInt" : 1, "myKeyStr" : "myOtherValue", "myKeyObj" : {"objKey" : "objValue" } }""")
+    val step = jsonStepBuilder.is("""{ "myKeyInt" : *any-integer*, "myKeyStr" : *any-string*, "myKeyObj" : *any-object* }""")
+    val s = Scenario("scenario with JsonSteps", step :: Nil)
+    val res = awaitIO(ScenarioRunner.runScenario(session)(s))
+    assert(res.isSuccess)
+  }
+
+  test("JsonStepBuilder.is json with duplicate matchers in object") {
+    val session = Session.newEmpty.addValuesUnsafe(testKey -> """{ "myKeyInt" : 1, "myKeyObj1" : {"objKey" : "objValue" } , "myKeyObj2" : {"objKey" : "objValue" } }""")
+    val step = jsonStepBuilder.is("""{ "myKeyInt" : *any-integer*, "myKeyObj1" : *any-object*, "myKeyObj2" : *any-object* }""")
     val s = Scenario("scenario with JsonSteps", step :: Nil)
     val res = awaitIO(ScenarioRunner.runScenario(session)(s))
     assert(res.isSuccess)

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/matchers/MatchersProperties.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/matchers/MatchersProperties.scala
@@ -3,15 +3,15 @@ package com.github.agourlay.cornichon.matchers
 import cats.Parallel
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
-
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import com.github.agourlay.cornichon.matchers.Matchers._
-import io.circe.Json
+import io.circe.{ Json, JsonObject }
+import io.circe.testing.ArbitraryInstances
 import org.scalacheck._
 import org.scalacheck.Prop._
 
-object MatchersProperties extends Properties("Matchers") {
+object MatchersProperties extends Properties("Matchers") with ArbitraryInstances {
 
   val reasonablyRandomInstantGen: Gen[Instant] = for {
     randomOffset <- Arbitrary.arbLong.arbitrary
@@ -79,4 +79,14 @@ object MatchersProperties extends Properties("Matchers") {
       res.forall(_ == true)
     }
   }
+
+  property("any-object correct for any JsonObject") =
+    forAll { jsonObj: JsonObject =>
+      anyObject.predicate(Json.fromJsonObject(jsonObj))
+    }
+
+  property("any-string correct for any asciiPrintableStr") =
+    forAll(Gen.asciiPrintableStr) { asciiPrintableStr =>
+      anyString.predicate(Json.fromString(asciiPrintableStr))
+    }
 }


### PR DESCRIPTION
Investigation for https://github.com/agourlay/cornichon/issues/676

In this PR the `MatcherResolver` does not assume anymore any particular ordering for the corresponding `JsonPath`.

Also `findAllPathWithValue` was greatly simplified, it should run much faster.