### PR TITLE
fix scala 2.12 compilation

### DIFF
--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/steps/HeadersSteps.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/http/steps/HeadersSteps.scala
@@ -19,7 +19,7 @@ object HeadersSteps {
           sessionHeaders <- sc.session.get(lastResponseHeadersKey)
           sessionHeadersValue <- decodeSessionHeaders(sessionHeaders)
           lowerCasedActual = sessionHeadersValue.map { case (name, value) => name.toLowerCase -> value }
-          expectedWithResolvedPlaceholders <- expected.traverse {
+          expectedWithResolvedPlaceholders <- expected.toList.traverse {
             case (name, value) =>
               sc.fillPlaceholders(value).map(v => (name, v))
           }
@@ -44,7 +44,7 @@ object HeadersSteps {
           sessionHeaders <- sc.session.get(lastResponseHeadersKey)
           sessionHeadersValue <- decodeSessionHeaders(sessionHeaders)
           lowerCasedActual = sessionHeadersValue.map { case (name, value) => name.toLowerCase -> value }
-          elementsWithResolvedPlaceholders <- elements.traverse {
+          elementsWithResolvedPlaceholders <- elements.toList.traverse {
             case (name, value) =>
               sc.fillPlaceholders(value).map(v => (name, v))
           }


### PR DESCRIPTION
Compilation error with scala 2.12:
```
core/src/main/scala/com/github/agourlay/cornichon/http/steps/HeadersSteps.scala:22:56: value traverse is not a member of (String, String)*
```

Using a `List` instead works in scala 2.12 & scala 2.13