### PR TITLE
use Java 11 bytecode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ lazy val standardSettings = Seq(
   licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
   Test / fork := true,
   scalacOptions ++= compilerOptions(scalaVersion.value),
-  scalacOptions += "-release:8",
+  scalacOptions += "-release:11", // caffeine requires Java 11
   javacOptions ++= Seq("-source", "8", "-target", "8"),
   // Additional meta-info required by maven central
   startYear := Some(2015),

--- a/cornichon-docs/docs/installation.md
+++ b/cornichon-docs/docs/installation.md
@@ -8,6 +8,8 @@ position: 1
 
 Cornichon is available for Scala 2.12 & Scala 2.13.
 
+It requires Java 11 or higher.
+
 The library is compatible with [SBT](https://www.scala-sbt.org/) and [Mill](http://www.lihaoyi.com/mill/).
 
 ``` scala


### PR DESCRIPTION
Since [0.19.7](https://github.com/agourlay/cornichon/releases/tag/v0.19.7) Java 11 is required at runtime due to the Caffeine library.

We might as well use more modern byte code when releasing.