### PR TITLE
Add WithJsonDataInputs to CoreDSL

### DIFF
--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/CoreDsl.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/CoreDsl.scala
@@ -121,6 +121,11 @@ trait CoreDsl {
       WithDataInputStep(steps, where)
     }
 
+  def WithJsonDataInputs(where: String): BodyElementCollector[Step, Step] =
+    BodyElementCollector[Step, Step] { steps =>
+      WithDataInputStep(steps, where, rawJson = true)
+    }
+
   def wait(duration: FiniteDuration): Step = EffectStep.fromAsync(
     title = s"wait for ${duration.toMillis} millis",
     effect = sc => IO.delay(sc.session).delayBy(duration)

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/steps/wrapped/WithDataInputStep.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/steps/wrapped/WithDataInputStep.scala
@@ -8,7 +8,7 @@ import com.github.agourlay.cornichon.core.ScenarioRunner._
 import com.github.agourlay.cornichon.core.Done._
 import com.github.agourlay.cornichon.util.Printing._
 
-case class WithDataInputStep(nested: List[Step], where: String) extends WrapperStep {
+case class WithDataInputStep(nested: List[Step], where: String, rawJson: Boolean = false) extends WrapperStep {
 
   val title = s"With data input block $where"
 
@@ -41,7 +41,7 @@ case class WithDataInputStep(nested: List[Step], where: String) extends WrapperS
         t => IO.pure(handleErrors(this, runState, NonEmptyList.one(t))),
         parsedTable => {
           val inputs = parsedTable.map { line =>
-            line.toList.map { case (key, json) => (key, CornichonJson.jsonStringValue(json)) }
+            line.toList.map { case (key, json) => (key, if (rawJson) json.noSpacesSortKeys else CornichonJson.jsonStringValue(json)) }
           }
 
           runInputs(inputs, runState.nestedContext)


### PR DESCRIPTION
Hello!

I was trying to create a test like this (simplified for the example):
```
    Scenario("Create a cart") {
      WithDataInputs("""
          | cart-cust |
          | "cust1"   |
          | null      |
         """) {
        When I post("/carts").withBody(s"""
          {
            "customerId": <cart-cust>
          }
        """)
        Then assert status.is(201)
      }
    }
```

But this of course failed because the placeholder always contains just a string and `null` in the data table translates to an empty string. The actual string is also not surrounded by quotes.

I solved it by grabbing the session and extracting the value manually and checking if it was an empty string and then building up my json body to post accordingly, but it was a lot more fuss.

Therefore I am proposing this addition to the DSL. If there is a simpler way to accomplish what I was trying to do, please let me know. :)