### PR TITLE
Introduce 'EventuallyDiscard' to discard inner failing states

### DIFF
--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/CoreDsl.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/CoreDsl.scala
@@ -92,7 +92,15 @@ trait CoreDsl {
   def Eventually(maxDuration: FiniteDuration, interval: FiniteDuration, oscillationAllowed: Boolean = true): BodyElementCollector[Step, Step] =
     BodyElementCollector[Step, Step] { steps =>
       val conf = EventuallyConf(maxDuration, interval)
-      EventuallyStep(steps, conf, oscillationAllowed)
+      EventuallyStep(steps, conf, oscillationAllowed, discardStateOnError = false)
+    }
+
+  // Same as Eventually but will discard the resulting inner state (session & logs) if one of the wrapped step fails.
+  // This prevents the session to grow excessively in case of long wait times.
+  def EventuallyDiscard(maxDuration: FiniteDuration, interval: FiniteDuration): BodyElementCollector[Step, Step] =
+    BodyElementCollector[Step, Step] { steps =>
+      val conf = EventuallyConf(maxDuration, interval)
+      EventuallyStep(steps, conf, oscillationAllowed = true, discardStateOnError = true)
     }
 
   def RepeatConcurrently(times: Int, parallelism: Int, maxTime: FiniteDuration): BodyElementCollector[Step, Step] =

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/steps/wrapped/EventuallyStep.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/steps/wrapped/EventuallyStep.scala
@@ -14,7 +14,7 @@ case class EventuallyStep(nested: List[Step], conf: EventuallyConf, oscillationA
 
   override val stateUpdate: StepState = StateT { runState =>
 
-    def retryEventuallySteps(runState: RunState, conf: EventuallyConf, retriesNumber: Long, knownErrors: List[FailedStep]): IO[(Long, Int, RunState, Either[FailedStep, Done])] = {
+    def retryEventuallySteps(runState: RunState, conf: EventuallyConf, retriesNumber: Long, knownErrors: List[FailedStep], lastErrorState: Option[RunState]): IO[(Long, Int, RunState, Either[FailedStep, Done])] = {
 
       def distinctErrorsWith(fs: FailedStep): Int =
         (fs :: knownErrors).toSet.size
@@ -38,34 +38,48 @@ case class EventuallyStep(nested: List[Step], conf: EventuallyConf, oscillationA
                 // early exit for oscillation detection
                 if (oscillationDetected) {
                   val fsOscillation = FailedStep.fromSingle(this, EventuallyBlockOscillationDetected(failedStep))
-                  return IO.pure((retriesNumber, distinctErrors, newRunState, fsOscillation.asLeft))
-                }
-
-                // control precisely which state is propagated
-                val updatedRunState = {
-                  if (discardStateOnError) {
-                    // discard inner session and logs
-                    runState.registerCleanupSteps(newRunState.cleanupSteps)
-                  } else if (knownErrors.contains(failedStep)) {
-                    // known error only propagate cleanup steps and session as we know the logs already
-                    runState.registerCleanupSteps(newRunState.cleanupSteps).withSession(newRunState.session)
-                  } else {
-                    // new error - return the whole inner state
-                    newRunState
+                  IO.pure((retriesNumber, distinctErrors, newRunState, fsOscillation.asLeft))
+                } else {
+                  // control precisely which state is propagated
+                  val updatedRunState = {
+                    if (discardStateOnError) {
+                      // discard inner session and logs
+                      runState.registerCleanupSteps(newRunState.cleanupSteps)
+                    } else if (knownErrors.contains(failedStep)) {
+                      // known error only propagate cleanup steps and session as we know the logs already
+                      runState.registerCleanupSteps(newRunState.cleanupSteps).withSession(newRunState.session)
+                    } else {
+                      // new error - return the whole inner state
+                      newRunState
+                    }
                   }
-                }
 
-                // Check that it could go through another loop after the interval
-                if ((remainingTime - conf.interval).gt(Duration.Zero))
-                  retryEventuallySteps(updatedRunState, conf.consume(executionTime), retriesNumber + 1, failedStep :: knownErrors)
-                else {
-                  IO.pure((retriesNumber, distinctErrorsWith(failedStep), updatedRunState, failedStep.asLeft))
+                  // Check that it could go through another loop after the interval
+                  if ((remainingTime - conf.interval).gt(Duration.Zero))
+                    retryEventuallySteps(updatedRunState, conf.consume(executionTime), retriesNumber + 1, failedStep :: knownErrors, Some(newRunState))
+                  else {
+                    // no time for another loop
+                    if (discardStateOnError) {
+                      // return last state fully because intermediate states were discarded
+                      IO.pure((retriesNumber, distinctErrorsWith(failedStep), newRunState, failedStep.asLeft))
+                    } else {
+                      // return subset of error state
+                      IO.pure((retriesNumber, distinctErrorsWith(failedStep), updatedRunState, failedStep.asLeft))
+                    }
+                  }
                 }
 
               case Right(_) =>
                 if (remainingTime.gt(Duration.Zero)) {
-                  // In case of success all logs are returned but they are not printed by default.
-                  IO.pure((retriesNumber, distinctErrors, newRunState, rightDone))
+                  lastErrorState match {
+                    case Some(prevErrorState) if discardStateOnError =>
+                      // only show the last error
+                      val mergedState = prevErrorState.mergeNested(newRunState)
+                      IO.pure((retriesNumber, distinctErrors, mergedState, Done.rightDone))
+                    case _ =>
+                      // In case of success all logs are returned but they are not printed by default.
+                      IO.pure((retriesNumber, distinctErrors, newRunState, rightDone))
+                  }
                 } else {
                   // Run was a success but the time is up.
                   val failedStep = FailedStep.fromSingle(nested.last, EventuallyBlockSucceedAfterMaxDuration)
@@ -80,7 +94,7 @@ case class EventuallyStep(nested: List[Step], conf: EventuallyConf, oscillationA
       IO.delay((0, 0, runState.nestedContext, fs.asLeft[Done]))
     }
 
-    retryEventuallySteps(runState.nestedContext, conf, 0, Nil)
+    retryEventuallySteps(runState.nestedContext, conf, 0, Nil, None)
       .timeoutTo(duration = conf.maxTime * 2, fallback = timeoutFailedResult) // make sure that the inner block does not run forever
       .timed
       .map {

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/testHelpers/CommonTestSuite.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/testHelpers/CommonTestSuite.scala
@@ -16,8 +16,7 @@ trait CommonTestSuite extends CommonTesting {
         }
         assert(f.msg == expectedMessage)
       case other =>
-        println(s"Should have been a FailedScenarioReport but got \n${LogInstruction.renderLogs(other.logs)}")
-        assert(false)
+        fail(s"Should have been a FailedScenarioReport but got \n${LogInstruction.renderLogs(other.logs)}")
     }
 
   def matchLogsWithoutDuration(logs: List[LogInstruction])(expectedRenderedLogs: String): Unit = {
@@ -36,6 +35,6 @@ trait CommonTestSuite extends CommonTesting {
       else l
     }
     val preparedCleanedLogs = cleanedLogs.mkString("\n")
-    assert(preparedCleanedLogs == expectedRenderedLogs)
+    assertEquals(preparedCleanedLogs, expectedRenderedLogs)
   }
 }


### PR DESCRIPTION
This PR adds a new DSL construct name `EventuallyDiscard` to tackle the issue of large sessions #769 

It is equivalent to `Eventually` but will discard the resulting inner state (session & logs) if one of the wrapped step fails.