### PR TITLE
New resource step with explicit scopes

### DIFF
--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/RunState.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/RunState.scala
@@ -20,6 +20,7 @@ case class RunState(
   // Only the session is propagated downstream as it is.
   lazy val nestedContext: RunState = copy(depth = depth + 1, logStack = Nil, cleanupSteps = Nil)
   lazy val sameLevelContext: RunState = copy(logStack = Nil, cleanupSteps = Nil)
+  lazy val upperLevelContext: RunState = copy(depth = depth - 1, logStack = Nil, cleanupSteps = Nil)
 
   def withSession(s: Session): RunState = copy(session = s)
   def addToSession(tuples: Seq[(String, String)]): RunState = withSession(session.addValuesUnsafe(tuples: _*))

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Step.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/core/Step.scala
@@ -139,3 +139,5 @@ trait WrapperStep extends Step {
   def successTitleLog(depth: Int) = SuccessLogInstruction(title, depth)
 }
 
+// Describes the lifecycle of a resource
+case class Resource(title: String, acquire: Step, release: Step)

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/CoreDsl.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/dsl/CoreDsl.scala
@@ -4,7 +4,7 @@ import cats.Show
 import cats.syntax.either._
 import cats.syntax.show._
 import cats.effect.IO
-import com.github.agourlay.cornichon.core.{ CornichonError, FeatureDef, ScenarioContext, Session, SessionKey, Step, Scenario => ScenarioDef }
+import com.github.agourlay.cornichon.core.{ CornichonError, FeatureDef, Resource, ScenarioContext, Session, SessionKey, Step, Scenario => ScenarioDef }
 import com.github.agourlay.cornichon.dsl.SessionSteps.{ SessionHistoryStepBuilder, SessionStepBuilder, SessionValuesStepBuilder }
 import com.github.agourlay.cornichon.steps.cats.EffectStep
 import com.github.agourlay.cornichon.steps.regular.DebugStep
@@ -123,6 +123,11 @@ trait CoreDsl {
   def WithJsonDataInputs(where: String): BodyElementCollector[Step, Step] =
     BodyElementCollector[Step, Step] { steps =>
       WithDataInputStep(steps, where, rawJson = true)
+    }
+
+  def WithResource(resource: Resource): BodyElementCollector[Step, Step] =
+    BodyElementCollector[Step, Step] { steps =>
+      WithResourceStep(steps, resource)
     }
 
   def wait(duration: FiniteDuration): Step = EffectStep.fromAsync(

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/steps/wrapped/WithResourceStep.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/steps/wrapped/WithResourceStep.scala
@@ -1,0 +1,49 @@
+package com.github.agourlay.cornichon.steps.wrapped
+
+import cats.data.StateT
+import cats.effect.IO
+import com.github.agourlay.cornichon.core.Done.rightDone
+import com.github.agourlay.cornichon.core.{ FailureLogInstruction, Resource, ScenarioRunner, Step, StepState, SuccessLogInstruction, WrapperStep }
+
+// The `Resource` is created before `nested` and released after
+case class WithResourceStep(nested: List[Step], resource: Resource) extends WrapperStep {
+  val title = s"With resource block `${resource.title}`"
+
+  override val stateUpdate: StepState = StateT { runState =>
+    val initialDepth = runState.depth
+    val resourceNested = runState.nestedContext
+    ScenarioRunner.runStepsShortCircuiting(resource.acquire :: Nil, resourceNested).flatMap { resTuple =>
+      val (acquireState, acquireRes) = resTuple
+      acquireRes match {
+        case Left(_) =>
+          val logs = FailureLogInstruction("With resource block failed due to acquire step", initialDepth) +: acquireState.logStack :+ failedTitleLog(initialDepth)
+          IO.pure((runState.mergeNested(acquireState, logs), acquireRes))
+        case Right(_) =>
+          val nestedNested = acquireState.nestedContext
+          ScenarioRunner.runStepsShortCircuiting(nested, nestedNested).flatMap { resTuple =>
+            val (nestedState, nestedRes) = resTuple
+            // always trigger resource release
+            ScenarioRunner.runStepsShortCircuiting(resource.release :: Nil, nestedState.upperLevelContext).flatMap { resTuple =>
+              val (releaseState, releaseRes) = resTuple
+              // gather all logs
+              val innerLogs = releaseState.logStack ::: nestedState.logStack ::: acquireState.logStack
+              val (report, logs) = (nestedRes, releaseRes) match {
+                case (Left(_), _) =>
+                  (nestedRes, FailureLogInstruction("With resource block failed", initialDepth) +: innerLogs :+ failedTitleLog(initialDepth))
+                case (_, Left(_)) =>
+                  (releaseRes, FailureLogInstruction("With resource block failed due to release step", initialDepth) +: innerLogs :+ failedTitleLog(initialDepth))
+                case _ =>
+                  (rightDone, SuccessLogInstruction("With resource block succeeded", initialDepth) +: innerLogs :+ successTitleLog(initialDepth))
+              }
+              // propagate potential cleanup steps
+              val mergedState = runState.recordLogStack(logs)
+                .registerCleanupSteps(nestedState.cleanupSteps)
+                .registerCleanupSteps(acquireState.cleanupSteps)
+                .registerCleanupSteps(releaseState.cleanupSteps)
+              IO.pure((mergedState, report))
+            }
+          }
+      }
+    }
+  }
+}

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/WithResourceStepSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/steps/wrapped/WithResourceStepSpec.scala
@@ -1,0 +1,142 @@
+package com.github.agourlay.cornichon.steps.wrapped
+
+import com.github.agourlay.cornichon.testHelpers.CommonTestSuite
+import com.github.agourlay.cornichon.core.{ Resource, Scenario, ScenarioRunner, Session }
+import com.github.agourlay.cornichon.steps.regular.assertStep.{ AssertStep, Assertion }
+import munit.FunSuite
+
+class WithResourceStepSpec extends FunSuite with CommonTestSuite {
+
+  test("succeed if acquire + nested + release are valid") {
+    val resource = Resource(
+      "super neat resource",
+      acquire = AssertStep("Acquire step", _ => Assertion.alwaysValid),
+      release = AssertStep("Release step", _ => Assertion.alwaysValid))
+
+    val nested = AssertStep("Nested step", _ => Assertion.alwaysValid) :: Nil
+    val withResourceStep = WithResourceStep(nested, resource)
+    val s = Scenario("scenario with resource that fails", withResourceStep :: Nil)
+    val res = awaitIO(ScenarioRunner.runScenario(Session.newEmpty)(s))
+    assert(res.isSuccess)
+
+    matchLogsWithoutDuration(res.logs) {
+      """
+        |   Scenario : scenario with resource that fails
+        |      main steps
+        |      With resource block `super neat resource`
+        |         Acquire step
+        |            Nested step
+        |         Release step
+        |      With resource block succeeded""".stripMargin
+    }
+  }
+
+  test("fails if acquire fails") {
+    val resource = Resource(
+      "super neat resource",
+      acquire = AssertStep("Acquire step", _ => Assertion.failWith("Something went wrong")),
+      release = AssertStep("Release step", _ => Assertion.alwaysValid))
+
+    val nested = AssertStep("Nested step", _ => Assertion.alwaysValid) :: Nil
+    val withResourceStep = WithResourceStep(nested, resource)
+    val s = Scenario("scenario with resource that fails", withResourceStep :: Nil)
+    val res = awaitIO(ScenarioRunner.runScenario(Session.newEmpty)(s))
+    scenarioFailsWithMessage(res) {
+      """Scenario 'scenario with resource that fails' failed:
+        |
+        |at step:
+        |Acquire step
+        |
+        |with error(s):
+        |Something went wrong
+        |
+        |seed for the run was '1'
+        |""".stripMargin
+    }
+
+    matchLogsWithoutDuration(res.logs) {
+      """
+        |   Scenario : scenario with resource that fails
+        |      main steps
+        |      With resource block `super neat resource`
+        |         Acquire step
+        |         *** FAILED ***
+        |         Something went wrong
+        |      With resource block failed due to acquire step""".stripMargin
+    }
+  }
+
+  test("fails if nested fails") {
+    val resource = Resource(
+      "super neat resource",
+      acquire = AssertStep("Acquire step", _ => Assertion.alwaysValid),
+      release = AssertStep("Release step", _ => Assertion.alwaysValid))
+
+    val nested = AssertStep("Nested step", _ => Assertion.failWith("Something went wrong")) :: Nil
+    val withResourceStep = WithResourceStep(nested, resource)
+    val s = Scenario("scenario with resource that fails", withResourceStep :: Nil)
+    val res = awaitIO(ScenarioRunner.runScenario(Session.newEmpty)(s))
+    scenarioFailsWithMessage(res) {
+      """Scenario 'scenario with resource that fails' failed:
+        |
+        |at step:
+        |Nested step
+        |
+        |with error(s):
+        |Something went wrong
+        |
+        |seed for the run was '1'
+        |""".stripMargin
+    }
+
+    matchLogsWithoutDuration(res.logs) {
+      """
+        |   Scenario : scenario with resource that fails
+        |      main steps
+        |      With resource block `super neat resource`
+        |         Acquire step
+        |            Nested step
+        |            *** FAILED ***
+        |            Something went wrong
+        |         Release step
+        |      With resource block failed""".stripMargin
+    }
+  }
+
+  test("fails if release fails") {
+    val resource = Resource(
+      "super neat resource",
+      acquire = AssertStep("Acquire step", _ => Assertion.alwaysValid),
+      release = AssertStep("Release step", _ => Assertion.failWith("Something went wrong")))
+
+    val nested = AssertStep("Nested step", _ => Assertion.alwaysValid) :: Nil
+    val withResourceStep = WithResourceStep(nested, resource)
+    val s = Scenario("scenario with resource that fails", withResourceStep :: Nil)
+    val res = awaitIO(ScenarioRunner.runScenario(Session.newEmpty)(s))
+    scenarioFailsWithMessage(res) {
+      """Scenario 'scenario with resource that fails' failed:
+        |
+        |at step:
+        |Release step
+        |
+        |with error(s):
+        |Something went wrong
+        |
+        |seed for the run was '1'
+        |""".stripMargin
+    }
+
+    matchLogsWithoutDuration(res.logs) {
+      """
+        |   Scenario : scenario with resource that fails
+        |      main steps
+        |      With resource block `super neat resource`
+        |         Acquire step
+        |            Nested step
+        |         Release step
+        |         *** FAILED ***
+        |         Something went wrong
+        |      With resource block failed due to release step""".stripMargin
+    }
+  }
+}


### PR DESCRIPTION
Tackles https://github.com/agourlay/cornichon/issues/237

This PR introduces a new abstraction for resource steps which are released at the end of a wrapping scope.

See integration test for example.