### PR TITLE
json matcher can ignore array ordering

### DIFF
--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/json/CornichonJson.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/json/CornichonJson.scala
@@ -1,6 +1,7 @@
 package com.github.agourlay.cornichon.json
 
-import cats.Show
+import cats.{ Eq, Show }
+import cats.data.Chain
 import cats.syntax.show._
 import cats.syntax.either._
 import com.github.agourlay.cornichon.core.{ CornichonError, Session }
@@ -10,6 +11,7 @@ import diffson.lcs._
 import diffson.circe._
 import diffson.jsonpatch._
 import diffson.jsonpatch.lcsdiff.remembering._
+import diffson.jsonpointer.{ Part, Pointer }
 import io.circe._
 import io.circe.syntax._
 import sangria.marshalling.MarshallingUtil._
@@ -190,8 +192,49 @@ trait CornichonJson {
 
   implicit private val lcs: Patience[Json] = new Patience[Json]
 
-  def diffPatch(first: Json, second: Json): JsonPatch[Json] =
-    diff(first, second)
+  private def pathWithoutIndex(path: Pointer): Chain[Part] = {
+    path.parts.map {
+      case s @ Left(_) => s
+      case Right(_)    => Right(0)
+    }
+  }
+
+  def diffPatch(first: Json, second: Json, ignoreArrayOrdering: Boolean): JsonPatch[Json] = {
+    val allDiffs = diff(first, second)
+    if (!ignoreArrayOrdering) {
+      allDiffs
+    } else {
+      val eqJson: Eq[Json] = implicitly
+      val newDiffs: List[Operation[Json]] = allDiffs.ops.foldLeft(List.empty[Operation[Json]]) {
+        case (acc, e) =>
+          e match {
+            case a @ Add(path, value) =>
+              val aWithoutIndex = pathWithoutIndex(path)
+              println(aWithoutIndex)
+              val removed = allDiffs.ops.exists {
+                case Remove(path, rValue) if pathWithoutIndex(path) == aWithoutIndex && rValue.exists(v => eqJson.eqv(v, value)) => true
+                case _ => false
+              }
+              if (removed) acc else a :: acc
+
+            case r @ Remove(path, value) =>
+              value match {
+                case None => r :: acc
+                case Some(removedValue) =>
+                  val rWithoutIndex = pathWithoutIndex(path)
+                  val added = allDiffs.ops.exists {
+                    case Add(path, aValue) if pathWithoutIndex(path) == rWithoutIndex && eqJson.eqv(aValue, removedValue) => true
+                    case _                                                                                                => false
+                  }
+                  if (added) acc else r :: acc
+              }
+
+            case other => other :: acc
+          }
+      }
+      JsonPatch(newDiffs)
+    }
+  }
 
   def decodeAs[A: Decoder](json: Json): Either[CornichonError, A] =
     json.as[A].leftMap(df => JsonDecodingFailure(json, df.message))
@@ -199,8 +242,8 @@ trait CornichonJson {
   // `first` must be a STRICT subset of `second` in terms of keys.
   // Returns `first` populated with the missing keys from `second` or an error.
   // The goal is to perform diffs without providing all the keys.
-  def whitelistingValue(first: Json, second: Json): Either[CornichonError, Json] = {
-    val diffOps = diffPatch(first, second).ops
+  def whitelistingValue(first: Json, second: Json, ignoreArrayOrdering: Boolean): Either[CornichonError, Json] = {
+    val diffOps = diffPatch(first, second, ignoreArrayOrdering).ops
     val forbiddenPatchOps = diffOps.collect { case r: Remove[Json] => r }
     if (forbiddenPatchOps.isEmpty) {
       val addOps = diffOps.collect { case r: Add[Json] => r }

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/json/CornichonJson.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/json/CornichonJson.scala
@@ -194,6 +194,9 @@ trait CornichonJson {
 
   private def pathWithoutIndex(path: Pointer): Chain[Part] = {
     path.parts.map {
+      case Left("-") =>
+        // special case: in RFC 6902, the "-" character is used to index the end of the array
+        Right(0)
       case s @ Left(_) => s
       case Right(_)    => Right(0)
     }

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/json/CornichonJson.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/json/CornichonJson.scala
@@ -210,7 +210,6 @@ trait CornichonJson {
           e match {
             case a @ Add(path, value) =>
               val aWithoutIndex = pathWithoutIndex(path)
-              println(aWithoutIndex)
               val removed = allDiffs.ops.exists {
                 case Remove(path, rValue) if pathWithoutIndex(path) == aWithoutIndex && rValue.exists(v => eqJson.eqv(v, value)) => true
                 case _ => false

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/steps/regular/assertStep/Diff.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/steps/regular/assertStep/Diff.scala
@@ -26,7 +26,6 @@ object Diff {
       s"""|JSON patch between actual result and expected result is :
           |${diff.show}
       """.stripMargin.trim)
-
   }
 
   implicit val stringDiff: Diff[String] = new Diff[String] {

--- a/cornichon-core/src/main/scala/com/github/agourlay/cornichon/steps/regular/assertStep/Diff.scala
+++ b/cornichon-core/src/main/scala/com/github/agourlay/cornichon/steps/regular/assertStep/Diff.scala
@@ -19,11 +19,15 @@ object Diff {
     jp.asJson.spaces2
   }
 
-  implicit val jsonDiff: Diff[Json] = (left: Json, right: Json) => Some(
-    s"""|JSON patch between actual result and expected result is :
-        |${diffPatch(left, right).show}
-      """.stripMargin.trim
-  )
+  implicit def jsonDiff(ignoreArrayOrdering: Boolean): Diff[Json] = (left: Json, right: Json) => {
+    val diff = diffPatch(left, right, ignoreArrayOrdering)
+    if (diff.ops.isEmpty) None
+    else Some(
+      s"""|JSON patch between actual result and expected result is :
+          |${diff.show}
+      """.stripMargin.trim)
+
+  }
 
   implicit val stringDiff: Diff[String] = new Diff[String] {
     override def diff(left: String, right: String): Option[String] = None

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/json/CornichonJsonProperties.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/json/CornichonJsonProperties.scala
@@ -1,5 +1,6 @@
 package com.github.agourlay.cornichon.json
 
+import com.github.agourlay.cornichon.steps.regular.assertStep.Diff
 import io.circe.{ Json, JsonObject }
 import io.circe.testing.ArbitraryInstances
 import org.scalacheck.{ Gen, Properties, Test }
@@ -65,7 +66,7 @@ class CornichonJsonProperties extends Properties("CornichonJson") with Cornichon
 
   property("whitelisting on identical JSON has no effect") = {
     forAll { (json: Json) =>
-      whitelistingValue(json, json) == Right(json)
+      whitelistingValue(json, json, ignoreArrayOrdering = false) == Right(json)
     }
   }
 
@@ -74,8 +75,8 @@ class CornichonJsonProperties extends Properties("CornichonJson") with Cornichon
       val modifiedObj = jsonObj.add("extraKey", Json.fromString("extraValue"))
       val json = Json.fromJsonObject(jsonObj)
       val modifiedJson = Json.fromJsonObject(modifiedObj)
-      whitelistingValue(json, modifiedJson) == Right(modifiedJson) &&
-        whitelistingValue(modifiedJson, json) == Left(WhitelistingError(Seq("/extraKey"), json))
+      whitelistingValue(json, modifiedJson, ignoreArrayOrdering = false) == Right(modifiedJson) &&
+        whitelistingValue(modifiedJson, json, ignoreArrayOrdering = false) == Left(WhitelistingError(Seq("/extraKey"), json))
     }
   }
 
@@ -89,8 +90,8 @@ class CornichonJsonProperties extends Properties("CornichonJson") with Cornichon
         val json = Json.fromValues(jos.map(Json.fromJsonObject))
         val modifiedJson = Json.fromValues(modifiedList)
         val errors = modifiedList.iterator.zipWithIndex.map { case (_, i) => s"/$i/extraKey" }.toList
-        whitelistingValue(json, modifiedJson) == Right(modifiedJson) &&
-          whitelistingValue(modifiedJson, json) == Left(WhitelistingError(errors, json))
+        whitelistingValue(json, modifiedJson, ignoreArrayOrdering = false) == Right(modifiedJson) &&
+          whitelistingValue(modifiedJson, json, ignoreArrayOrdering = false) == Left(WhitelistingError(errors, json))
       }
     }
   }
@@ -104,8 +105,8 @@ class CornichonJsonProperties extends Properties("CornichonJson") with Cornichon
       if (jos.isEmpty)
         true
       else
-        whitelistingValue(json1, json2) == Left(WhitelistingError("/stitch1" :: Nil, json2)) &&
-          whitelistingValue(json2, json1) == Left(WhitelistingError("/stitch2" :: Nil, json1))
+        whitelistingValue(json1, json2, ignoreArrayOrdering = false) == Left(WhitelistingError("/stitch1" :: Nil, json2)) &&
+          whitelistingValue(json2, json1, ignoreArrayOrdering = false) == Left(WhitelistingError("/stitch2" :: Nil, json1))
     }
   }
 }

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/json/JsonStepsSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/json/JsonStepsSpec.scala
@@ -394,8 +394,8 @@ class JsonStepsSpec extends FunSuite with CommonTestSuite {
   }
 
   test("JsonStepBuilder.is json ignoring array ordering") {
-    val session = Session.newEmpty.addValuesUnsafe(testKey -> """[{ "value" : "1"}, {"value" : "2" }]""")
-    val step = jsonStepBuilder.ignoringArrayOrdering.is("""[{ "value" : "2"}, {"value" : "1" }]""")
+    val session = Session.newEmpty.addValuesUnsafe(testKey -> """[{"value" : "state" }, {"value" : "state1" }, {"value" : "state2" }, {"value" : "state3" }, {"value" : "state4" }]""")
+    val step = jsonStepBuilder.ignoringArrayOrdering.is("""[{ "value" : "state1"}, {"value" : "state2" }, {"value" : "state" }, {"value" : "state4" }, {"value" : "state3" }]""")
     val s = Scenario("scenario with JsonSteps", step :: Nil)
     val res = awaitIO(ScenarioRunner.runScenario(session)(s))
     assert(res.isSuccess)

--- a/cornichon-core/src/test/scala/com/github/agourlay/cornichon/steps/regular/assertStep/DiffSpec.scala
+++ b/cornichon-core/src/test/scala/com/github/agourlay/cornichon/steps/regular/assertStep/DiffSpec.scala
@@ -91,7 +91,7 @@ class DiffSpec extends FunSuite {
   }
 
   test("JSON diff for JString is done via JsonPatch") {
-    val diff = jsonDiff.diff(Json.fromString("test"), Json.fromString("test1"))
+    val diff = jsonDiff(ignoreArrayOrdering = false).diff(Json.fromString("test"), Json.fromString("test1"))
     val expected =
       """|JSON patch between actual result and expected result is :
            |[
@@ -106,7 +106,9 @@ class DiffSpec extends FunSuite {
   }
 
   test("JSON diff for JObject is done via JsonPatch") {
-    val diff = jsonDiff.diff(Json.fromFields(("test" -> Json.fromString("value")) :: Nil), Json.fromFields(("test" -> Json.fromString("new value")) :: Nil))
+    val diff = jsonDiff(ignoreArrayOrdering = false).diff(
+      Json.fromFields(("test" -> Json.fromString("value")) :: Nil),
+      Json.fromFields(("test" -> Json.fromString("new value")) :: Nil))
     val expected =
       """|JSON patch between actual result and expected result is :
            |[
@@ -121,7 +123,9 @@ class DiffSpec extends FunSuite {
   }
 
   test("JSON diff for JArray is done via JsonPatch") {
-    val diff = jsonDiff.diff(Json.fromValues(Json.fromFields(("test" -> Json.fromString("value")) :: Nil) :: Nil), Json.fromValues(Json.fromFields(("test" -> Json.fromString("new value")) :: Nil) :: Nil))
+    val diff = jsonDiff(ignoreArrayOrdering = false).diff(
+      Json.fromValues(Json.fromFields(("test" -> Json.fromString("value")) :: Nil) :: Nil),
+      Json.fromValues(Json.fromFields(("test" -> Json.fromString("new value")) :: Nil) :: Nil))
     val expected =
       """|JSON patch between actual result and expected result is :
            |[
@@ -133,5 +137,12 @@ class DiffSpec extends FunSuite {
            |  }
            |]""".stripMargin
     assert(diff.contains(expected))
+  }
+
+  test("JSON diff for JArray can ignore ordering") {
+    val diff = jsonDiff(ignoreArrayOrdering = true).diff(
+      Json.fromValues(Json.obj("name" -> Json.fromString("value1")) :: Json.obj("name" -> Json.fromString("value2")) :: Nil),
+      Json.fromValues(Json.obj("name" -> Json.fromString("value2")) :: Json.obj("name" -> Json.fromString("value1")) :: Nil))
+    assert(diff.isEmpty)
   }
 }


### PR DESCRIPTION
Add the possibility for the json matcher to ignore ordering in arrays.

I'm opening with PR with the minimal number of changes to make it work.
I can extend it with other test cases if needed.